### PR TITLE
fix: Retrieve embeddings in Astra adapter 'get'

### DIFF
--- a/packages/langchain-graph-retriever/src/langchain_graph_retriever/adapters/astra.py
+++ b/packages/langchain-graph-retriever/src/langchain_graph_retriever/adapters/astra.py
@@ -127,7 +127,9 @@ class AstraAdapter(Adapter[AstraDBVectorStore]):
         document = self.vector_store.document_codec.decode(hit)
         if document is None:
             return None
-        document[METADATA_EMBEDDING_KEY] = self.vector_store.document_codec.decode_vector(hit)
+        document.metadata[METADATA_EMBEDDING_KEY] = (
+            self.vector_store.document_codec.decode_vector(hit)
+        )
         return document
 
     async def aget(self, ids: Sequence[str], /, **kwargs: Any) -> list[Document]:
@@ -152,5 +154,7 @@ class AstraAdapter(Adapter[AstraDBVectorStore]):
         document = self.vector_store.document_codec.decode(hit)
         if document is None:
             return None
-        document[METADATA_EMBEDDING_KEY] = self.vector_store.document_codec.decode_vector(hit)
+        document.metadata[METADATA_EMBEDDING_KEY] = (
+            self.vector_store.document_codec.decode_vector(hit)
+        )
         return document

--- a/packages/langchain-graph-retriever/src/langchain_graph_retriever/graph_traversal_retriever.py
+++ b/packages/langchain-graph-retriever/src/langchain_graph_retriever/graph_traversal_retriever.py
@@ -11,10 +11,10 @@ from langchain_core.documents import Document
 from langchain_core.retrievers import BaseRetriever
 from pydantic import computed_field
 
+from .adapters.base import METADATA_EMBEDDING_KEY, Adapter
 from .edge import Edge
 from .edge_helper import EdgeHelper
 from .node import Node
-from .adapters.base import METADATA_EMBEDDING_KEY, Adapter
 from .strategy.base import Strategy
 
 INFINITY = float("inf")

--- a/packages/langchain-graph-retriever/tests/integration_tests/conftest.py
+++ b/packages/langchain-graph-retriever/tests/integration_tests/conftest.py
@@ -1,5 +1,5 @@
-from tests.integration_tests.invoker import invoker
 from tests.integration_tests.animal_docs import animal_docs, animal_store
+from tests.integration_tests.invoker import invoker
 
 # Imports for definitions.
 from tests.integration_tests.stores import (

--- a/packages/langchain-graph-retriever/tests/integration_tests/stores.py
+++ b/packages/langchain-graph-retriever/tests/integration_tests/stores.py
@@ -5,10 +5,10 @@ import pytest
 from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
 from langchain_core.vectorstores import VectorStore
+from langchain_graph_retriever.adapters import Adapter
 from langchain_graph_retriever.document_transformers.metadata_denormalizer import (
     MetadataDenormalizer,
 )
-from langchain_graph_retriever.adapters import Adapter
 
 ALL_STORES = ["mem_norm", "mem", "astra", "cassandra", "chroma", "opensearch"]
 TESTCONTAINER_STORES = ["cassandra", "opensearch"]

--- a/packages/langchain-graph-retriever/tests/integration_tests/test_graph_traversal_eager.py
+++ b/packages/langchain-graph-retriever/tests/integration_tests/test_graph_traversal_eager.py
@@ -7,11 +7,11 @@ from langchain_graph_retriever.strategy.eager import (
     Eager,
 )
 from tests.embeddings.simple_embeddings import EarthEmbeddings, ParserEmbeddings
-from tests.integration_tests.assertions import assert_document_format, sorted_doc_ids
 from tests.integration_tests.animal_docs import (
     ANIMALS_DEPTH_0_EXPECTED,
     ANIMALS_QUERY,
 )
+from tests.integration_tests.assertions import assert_document_format, sorted_doc_ids
 from tests.integration_tests.stores import Adapter, StoreFactory
 
 

--- a/packages/langchain-graph-retriever/tests/integration_tests/test_graph_traversal_mmr.py
+++ b/packages/langchain-graph-retriever/tests/integration_tests/test_graph_traversal_mmr.py
@@ -8,11 +8,11 @@ from langchain_graph_retriever.strategy.mmr import (
     Mmr,
 )
 from tests.embeddings.simple_embeddings import Angular2DEmbeddings
-from tests.integration_tests.assertions import sorted_doc_ids
 from tests.integration_tests.animal_docs import (
     ANIMALS_DEPTH_0_EXPECTED,
     ANIMALS_QUERY,
 )
+from tests.integration_tests.assertions import sorted_doc_ids
 from tests.integration_tests.stores import Adapter
 
 

--- a/packages/langchain-graph-retriever/tests/unit_tests/test_adapter.py
+++ b/packages/langchain-graph-retriever/tests/unit_tests/test_adapter.py
@@ -1,5 +1,5 @@
-from langchain_graph_retriever.edge import Edge
 from langchain_graph_retriever.adapters import Adapter
+from langchain_graph_retriever.edge import Edge
 
 
 class FakeAdapter(Adapter):


### PR DESCRIPTION
This uses the underlying collections directly
since `AstraDBVectorStore` does not currently
expose a `get_by_document_id_with_embedding`.