### PR TITLE
Reformat a bunch of pydocs

### DIFF
--- a/docs/_extensions/machow/interlinks/.gitignore
+++ b/docs/_extensions/machow/interlinks/.gitignore
@@ -1,0 +1,3 @@
+*.html
+*.pdf
+*_files/

--- a/docs/_extensions/machow/interlinks/_extension.yml
+++ b/docs/_extensions/machow/interlinks/_extension.yml
@@ -1,0 +1,7 @@
+title: Interlinks
+author: Michael Chow
+version: 1.1.0
+quarto-required: ">=1.2.0"
+contributes:
+  filters:
+    - interlinks.lua

--- a/docs/_extensions/machow/interlinks/interlinks.lua
+++ b/docs/_extensions/machow/interlinks/interlinks.lua
@@ -1,0 +1,254 @@
+local function read_inv_text(filename)
+    -- read file
+    local file = io.open(filename, "r")
+    if file == nil then
+        return nil
+    end
+    local str = file:read("a")
+    file:close()
+
+
+    local project = str:match("# Project: (%S+)")
+    local version = str:match("# Version: (%S+)")
+
+    local data = {project = project, version = version, items = {}}
+
+    local ptn_data =
+        "^" ..
+        "(.-)%s+" ..        -- name
+        "([%S:]-):" ..      -- domain
+        "([%S]+)%s+" ..     -- role
+        "(%-?%d+)%s+" ..     -- priority
+        "(%S*)%s+" ..       -- uri
+        "(.-)\r?$"         -- dispname
+
+
+    -- Iterate through each line in the file content
+    for line in str:gmatch("[^\r\n]+") do
+        if not line:match("^#") then
+            -- Match each line against the pattern
+            local name, domain, role, priority, uri, dispName = line:match(ptn_data)
+
+            -- if name is nil, raise an error
+            if name == nil then
+                error("Error parsing line: " .. line)
+            end
+
+            data.items[#data.items + 1] = {
+                name = name,
+                domain = domain,
+                role = role,
+                priority = priority,
+                uri = uri,
+                dispName = dispName
+            }
+        end
+    end
+    return data
+end
+
+local function read_json(filename)
+
+    local file = io.open(filename, "r")
+    if file == nil then
+        return nil
+    end
+    local str = file:read("a")
+    file:close()
+
+    local decoded = quarto.json.decode(str)
+    return decoded
+end
+
+local function read_inv_text_or_json(base_name)
+    local file = io.open(base_name .. ".txt", "r")
+    if file then
+        -- TODO: refactors so we don't just close the file immediately
+        io.close(file)
+        json = read_inv_text(base_name .. ".txt")
+
+    else
+        json = read_json(base_name .. ".json")
+    end
+
+    return json
+end
+
+local inventory = {}
+
+local function lookup(search_object)
+
+    local results = {}
+    for _, inv in ipairs(inventory) do
+        for _, item in ipairs(inv.items) do
+            -- e.g. :external+<inv_name>:<domain>:<role>:`<name>`
+            if item.inv_name and item.inv_name ~= search_object.inv_name then
+                goto continue
+            end
+
+            if item.name ~= search_object.name then
+                goto continue
+            end
+
+            if search_object.role and item.role ~= search_object.role then
+                goto continue
+            end
+
+            if search_object.domain and item.domain ~= search_object.domain then
+                goto continue
+            else
+                if search_object.domain or item.domain == "py" then
+                  table.insert(results, item)
+                end
+
+                goto continue
+            end
+
+            ::continue::
+        end
+    end
+
+    if #results == 1 then
+        return results[1]
+    end
+    if #results > 1 then
+        quarto.log.warning("Found multiple matches for " .. search_object.name .. ", using the first match.")
+        return results[1]
+    end
+    if #results == 0 then
+        quarto.log.warning("Found no matches for object:\n", search_object)
+    end
+
+    return nil
+end
+
+local function mysplit (inputstr, sep)
+    if sep == nil then
+            sep = "%s"
+    end
+    local t={}
+    for str in string.gmatch(inputstr, "([^"..sep.."]+)") do
+            table.insert(t, str)
+    end
+    return t
+end
+
+local function normalize_role(role)
+    if role == "func" then
+        return "function"
+    end
+    return role
+end
+
+local function build_search_object(str)
+    local starts_with_colon = str:sub(1, 1) == ":"
+    local search = {}
+    if starts_with_colon then
+        local t = mysplit(str, ":")
+        if #t == 2 then
+            -- e.g. :py:func:`my_func`
+            search.role = normalize_role(t[1])
+            search.name = t[2]:match("%%60(.*)%%60")
+        elseif #t == 3 then
+            -- e.g. :py:func:`my_func`
+            search.domain = t[1]
+            search.role = normalize_role(t[2])
+            search.name = t[3]:match("%%60(.*)%%60")
+        elseif #t == 4 then
+            -- e.g. :ext+inv:py:func:`my_func`
+            search.external = true
+
+            search.inv_name = t[1]:match("external%+(.*)")
+            search.domain = t[2]
+            search.role = normalize_role(t[3])
+            search.name = t[4]:match("%%60(.*)%%60")
+        else
+            quarto.log.warning("couldn't parse this link: " .. str)
+            return {}
+        end
+    else
+        search.name = str:match("%%60(.*)%%60")
+    end
+
+    if search.name == nil then
+        quarto.log.warning("couldn't parse this link: " .. str)
+        return {}
+    end
+
+    if search.name:sub(1, 1) == "~" then
+        search.shortened = true
+        search.name = search.name:sub(2, -1)
+    end
+    return search
+end
+
+local function report_broken_link(link, search_object, replacement)
+    -- TODO: how to unescape html elements like [?
+    return pandoc.Code(pandoc.utils.stringify(link.content))
+end
+
+function Link(link)
+    -- do not process regular links ----
+    if not link.target:match("%%60") then
+        return link
+    end
+
+    -- lookup item ----
+    local search = build_search_object(link.target)
+    local item = lookup(search)
+
+    -- determine replacement, used if no link text specified ----
+    local original_text = pandoc.utils.stringify(link.content)
+    local replacement = search.name
+    if search.shortened then
+        local t = mysplit(search.name, ".")
+        replacement = t[#t]
+    end
+
+    -- set link text ----
+    if original_text == "" and replacement ~= nil then
+        link.content = pandoc.Code(replacement)
+    end
+
+    -- report broken links ----
+    if item == nil then
+        return report_broken_link(link, search)
+    end
+    link.target = item.uri:gsub("%$$", search.name)
+
+
+    return link
+end
+
+local function fixup_json(json, prefix)
+    for _, item in ipairs(json.items) do
+        item.uri = prefix .. item.uri
+    end
+    table.insert(inventory, json)
+end
+
+return {
+    {
+        Meta = function(meta)
+            local json
+            local prefix
+            if meta.interlinks and meta.interlinks.sources then
+                for k, v in pairs(meta.interlinks.sources) do
+                    local base_name = quarto.project.offset .. "/_inv/" .. k .. "_objects"
+                    json = read_inv_text_or_json(base_name)
+                    prefix = pandoc.utils.stringify(v.url)
+                    if json ~= nil then
+                        fixup_json(json, prefix)
+                    end
+                end
+            end
+            json = read_inv_text_or_json(quarto.project.offset .. "/objects")
+            if json ~= nil then
+                fixup_json(json, "/")
+            end
+        end
+    },
+    {
+        Link = Link
+    }
+}

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -88,3 +88,11 @@ quartodoc:
       - chroma.ChromaAdapter
       - in_memory.InMemoryAdapter
       - open_search.OpenSearchAdapter
+
+filters:
+  - interlinks
+
+interlinks:
+  sources:
+    python:
+      url: https://docs.python.org/3/

--- a/packages/langchain-graph-retriever/src/langchain_graph_retriever/_traversal.py
+++ b/packages/langchain-graph-retriever/src/langchain_graph_retriever/_traversal.py
@@ -12,7 +12,8 @@ from .strategies import Strategy
 
 
 class Traversal:
-    """Handles a single traversal operation for a graph-based retrieval system.
+    """
+    Handles a single traversal operation for a graph-based retrieval system.
 
     The `Traversal` class manages the process of discovering, visiting, and selecting
     nodes within a graph, based on a query and a traversal strategy. It supports
@@ -21,19 +22,24 @@ class Traversal:
 
     This class should not be reused between traversals.
 
-    Attributes
+    Parameters
     ----------
-        query (str): The query string for the traversal.
-        edges (EdgeHelper): A helper object for managing graph edges.
-        strategy (Strategy): The traversal strategy that defines how nodes are
-            discovered, selected, and finalized.
-        store (Adapter): The vector store adapter used for similarity searches and
-            document retrieval.
-        metadata_filter (dict[str, Any] | None): Optional filter for metadata during
-            traversal.
-        initial_root_ids (Sequence[str]): IDs of the initial root nodes for the
-            traversal.
-        store_kwargs (dict[str, Any]): Additional arguments passed to the store adapter.
+    query : str
+        The query string for the traversal.
+    edges : EdgeHelper
+        A helper object for managing graph edges.
+    strategy : Strategy
+        The traversal strategy that defines how nodes are discovered, selected,
+        and finalized.
+    store : Adapter
+        The vector store adapter used for similarity searches and document
+        retrieval.
+    metadata_filter : dict[str, Any], optional
+        Optional filter for metadata during traversal.
+    initial_root_ids : Sequence[str], optional
+        IDs of the initial root nodes for the traversal.
+    store_kwargs : dict[str, Any], optional
+        Additional arguments passed to the store adapter.
     """
 
     def __init__(
@@ -67,14 +73,16 @@ class Traversal:
         self._used = True
 
     def traverse(self) -> list[Document]:
-        """Execute the traversal synchronously.
+        """
+        Execute the traversal synchronously.
 
         This method retrieves initial candidates, discovers and visits nodes,
         and explores edges iteratively until the traversal is complete.
 
         Returns
         -------
-            list[Document]: The final set of documents resulting from the traversal.
+        list[Document]
+            The final set of documents resulting from the traversal.
         """
         self._check_first_use()
 
@@ -99,14 +107,16 @@ class Traversal:
         return self.finish()
 
     async def atraverse(self) -> list[Document]:
-        """Execute the traversal asynchronously.
+        """
+        Execute the traversal asynchronously.
 
         This method retrieves initial candidates, discovers and visits nodes,
         and explores edges iteratively until the traversal is complete.
 
         Returns
         -------
-            list[Document]: The final set of documents resulting from the traversal.
+        list[Document]
+            The final set of documents resulting from the traversal.
         """
         self._check_first_use()
 
@@ -131,12 +141,13 @@ class Traversal:
         return self.finish()
 
     def _fetch_initial_candidates(self) -> list[Document]:
-        """Retrieve initial candidates based on the query and strategy.
+        """
+        Retrieve initial candidates based on the query and strategy.
 
         Returns
         -------
-            list[Document]: The initial set of documents retrieved via similarity
-            search.
+        list[Document]
+            The initial set of documents retrieved via similarity search.
         """
         query_embedding, docs = self.store.similarity_search_with_embedding(
             query=self.query,
@@ -144,7 +155,7 @@ class Traversal:
             filter=self.metadata_filter,
             **self.store_kwargs,
         )
-        self.strategy.query_embedding = query_embedding
+        self.strategy._query_embedding = query_embedding
         return docs
 
     async def _afetch_initial_candidates(self) -> list[Document]:
@@ -154,11 +165,12 @@ class Traversal:
             filter=self.metadata_filter,
             **self.store_kwargs,
         )
-        self.strategy.query_embedding = query_embedding
+        self.strategy._query_embedding = query_embedding
         return docs
 
     def _fetch_neighborhood_candidates(self) -> Iterable[Document]:
-        """Retrieve neighborhood candidates for traversal.
+        """
+        Retrieve neighborhood candidates for traversal.
 
         This method fetches initial root documents, converts them to nodes, and records
         their outgoing edges as visited. It then fetches additional candidates adjacent
@@ -166,7 +178,8 @@ class Traversal:
 
         Returns
         -------
-            Iterable[Document]: The set of documents adjacent to the initial root nodes.
+        Iterable[Document]
+            The set of documents adjacent to the initial root nodes.
         """
         neighborhood_docs = self.store.get(self.initial_root_ids)
         neighborhood_nodes = self.add_docs(neighborhood_docs)
@@ -181,7 +194,8 @@ class Traversal:
     async def _afetch_neighborhood_candidates(
         self,
     ) -> Iterable[Document]:
-        """Asynchronously retrieve neighborhood candidates for traversal.
+        """
+        Asynchronously retrieve neighborhood candidates for traversal.
 
         This method fetches initial root documents, converts them to nodes, and records
         their outgoing edges as visited. It then fetches additional candidates adjacent
@@ -189,7 +203,8 @@ class Traversal:
 
         Returns
         -------
-            Iterable[Document]: The set of documents adjacent to the initial root nodes.
+        Iterable[Document]
+            The set of documents adjacent to the initial root nodes.
         """
         neighborhood_docs = await self.store.aget(self.initial_root_ids)
         neighborhood_nodes = self.add_docs(neighborhood_docs)
@@ -202,18 +217,21 @@ class Traversal:
         return await self._afetch_adjacent(outgoing_edges)
 
     def _fetch_adjacent(self, outgoing_edges: set[Edge]) -> Iterable[Document]:
-        """Retrieve documents adjacent to the specified outgoing edges.
+        """
+        Retrieve documents adjacent to the specified outgoing edges.
 
         This method uses the vector store adapter to fetch documents connected to
         the provided edges.
 
-        Args:
-            outgoing_edges (set[Edge]): The edges whose adjacent documents need to
-                be fetched.
+        Parameters
+        ----------
+        outgoing_edges : set[Edge]
+            The edges whose adjacent documents need to be fetched.
 
         Returns
         -------
-            Iterable[Document]: The set of documents adjacent to the specified edges.
+        Iterable[Document]
+            The set of documents adjacent to the specified edges.
         """
         return self.store.get_adjacent(
             outgoing_edges=outgoing_edges,
@@ -223,18 +241,21 @@ class Traversal:
         )
 
     async def _afetch_adjacent(self, outgoing_edges: set[Edge]) -> Iterable[Document]:
-        """Asynchronously retrieve documents adjacent to the specified outgoing edges.
+        """
+        Asynchronously retrieve documents adjacent to the specified outgoing edges.
 
         This method uses the vector store adapter to fetch documents connected to
         the provided edges.
 
-        Args:
-            outgoing_edges (set[Edge]): The edges whose adjacent documents need to
-                be fetched.
+        Parameters
+        ----------
+        outgoing_edges : set[Edge]
+            The edges whose adjacent documents need to be fetched.
 
         Returns
         -------
-            Iterable[Document]: The set of documents adjacent to the specified edges.
+        Iterable[Document]
+            The set of documents adjacent to the specified edges.
         """
         return await self.store.aget_adjacent(
             outgoing_edges=outgoing_edges,
@@ -246,25 +267,31 @@ class Traversal:
     def _doc_to_new_node(
         self, doc: Document, *, depth: int | None = None
     ) -> Node | None:
-        """Convert a document into a new node for the traversal.
+        """
+        Convert a document into a new node for the traversal.
 
         This method checks whether the document has already been processed. If not,
         it creates a new `Node` instance, associates it with the document's metadata,
         and calculates its depth based on the incoming edges.
 
-        Args:
-            doc (Document): The document to convert into a node.
-            depth (int | None, optional): The depth of the node. If None, the depth
-                is calculated based on the incoming edges.
+        Parameters
+        ----------
+        doc : Document
+            The document to convert into a node.
+        depth : int, optional
+            The depth of the node. If None, the depth is calculated based on the
+            incoming edges.
 
         Returns
         -------
-            Node | None: The newly created node, or None if the document has already
-            been processed.
+        Node | None:
+            The newly created node, or None if the document has already been
+            processed.
 
         Raises
         ------
-            ValueError: If the document does not have an ID.
+        ValueError
+            If the document does not have an ID.
         """
         if doc.id is None:
             raise ValueError("All documents should have ids")
@@ -298,19 +325,24 @@ class Traversal:
     def add_docs(
         self, docs: Iterable[Document], *, depth: int | None = None
     ) -> dict[str, Node]:
-        """Add a batch of documents to the traversal and convert them into nodes.
+        """
+        Add a batch of documents to the traversal and convert them into nodes.
 
         This method records the depth of new nodes, filters them based on the
         strategy's maximum depth, and updates the strategy with the discovered nodes.
 
-        Args:
-            docs (Iterable[Document]): The documents to add.
-            depth (int | None): The depth to assign to the nodes. If None, the depth
-                is inferred based on the incoming edges.
+        Parameters
+        ----------
+        docs : Iterable[Document]
+            The documents to add.
+        depth : int, optional
+            The depth to assign to the nodes. If None, the depth is inferred
+            based on the incoming edges.
 
         Returns
         -------
-            dict[str, Node]: A dictionary of node IDs to the newly created nodes.
+        dict[str, Node]
+            A dictionary of node IDs to the newly created nodes.
         """
         # Record the depth of new nodes.
         nodes = {
@@ -325,28 +357,32 @@ class Traversal:
         return nodes
 
     def visit_nodes(self, nodes: Iterable[Node]) -> set[Edge]:
-        """Mark nodes as visited and return their new outgoing edges.
+        """
+        Mark nodes as visited and return their new outgoing edges.
 
         This method updates the traversal state by marking the provided nodes as visited
         and recording their outgoing edges. Outgoing edges that have not been visited
         before are identified and added to the set of edges to explore in subsequent
         traversal steps.
 
-        Args:
-            nodes (Iterable[Node]): The nodes to mark as visited.
+        Parameters
+        ----------
+        nodes : Iterable[Node]
+            The nodes to mark as visited.
 
         Returns
         -------
-            set[Edge]: The set of new outgoing edges that need to be explored.
+        set[Edge]
+            The set of new outgoing edges that need to be explored.
 
         Notes
         -----
-            - The `new_outgoing_edges` dictionary tracks the depth of each outgoing
-            edge.
-            - If a node's outgoing edge leads to a lower depth, the edge's depth is
-            updated to reflect the shortest path.
-            - The `_visited_edges` set is updated to include all outgoing edges
-            from the provided nodes.
+        - The `new_outgoing_edges` dictionary tracks the depth of each outgoing
+        edge.
+        - If a node's outgoing edge leads to a lower depth, the edge's depth is
+        updated to reflect the shortest path.
+        - The `_visited_edges` set is updated to include all outgoing edges
+        from the provided nodes.
         """
         new_outgoing_edges: dict[Edge, int] = {}
         for node in nodes:
@@ -363,15 +399,17 @@ class Traversal:
         return new_outgoing_edge_set
 
     def select_next_edges(self) -> set[Edge] | None:
-        """Select the next set of edges to explore.
+        """
+        Select the next set of edges to explore.
 
         This method uses the traversal strategy to select the next batch of nodes
         and identifies new outgoing edges for exploration.
 
         Returns
         -------
-            set[Edge] | None: The set of new edges to explore, or None if the traversal
-            is complete.
+        set[Edge] | None
+            The set of new edges to explore, or None if the traversal is
+            complete.
         """
         remaining = self.strategy.k - len(self._selected_nodes)
 
@@ -391,14 +429,21 @@ class Traversal:
         return new_outgoing_edges
 
     def finish(self) -> list[Document]:
-        """Finalize the traversal and return the final set of documents.
+        """
+        Finalize the traversal and return the final set of documents.
 
         This method finalizes the selected nodes using the traversal strategy,
         processes their metadata, and assembles the final list of documents.
 
         Returns
         -------
-            list[Document]: The final set of documents resulting from the traversal.
+        list[Document]
+            The final set of documents resulting from the traversal.
+
+        Raises
+        ------
+        RuntimeError
+            If unexpected situations arise, such as a document missing from the cache.
         """
         final_nodes = self.strategy.finalize_nodes(self._selected_nodes.values())
         docs = []

--- a/packages/langchain-graph-retriever/src/langchain_graph_retriever/adapters/astra.py
+++ b/packages/langchain-graph-retriever/src/langchain_graph_retriever/adapters/astra.py
@@ -19,11 +19,16 @@ class AstraAdapter(Adapter[AstraDBVectorStore]):
     """
     Adapter for AstraDBVectorStore.
 
-    This adapter integrates the AstraDB vector store with the graph retriever system,
-    enabling similarity search and document retrieval.
+    This adapter provides DataStax AstraDB support for the graph retriever
+    system, enabling similarity search and document retrieval.
 
-    Args:
-        vector_store (AstraDBVectorStore): The AstraDB vector store instance.
+    It supports normalized metadata (collections of values) without
+    denormalization.
+
+    Parameters
+    ----------
+    vector_store : AstraDBVectorStore
+        The AstraDB vector store instance.
     """
 
     def __init__(self, vector_store: AstraDBVectorStore):
@@ -128,13 +133,15 @@ class AstraAdapter(Adapter[AstraDBVectorStore]):
         """
         Retrieve a document by its ID, including its embedding.
 
-        Args:
-            document_id (str): The document ID.
+        Parameters
+        ----------
+        document_id : str
+            The document ID.
 
         Returns
         -------
-            Document | None: The retrieved document with embedding, or None if not
-                found.
+        Document | None
+            The retrieved document with embedding, or `None` if not found.
         """
         self.vector_store.astra_env.ensure_db_setup()
 
@@ -166,13 +173,15 @@ class AstraAdapter(Adapter[AstraDBVectorStore]):
         """
         Asynchronously retrieve a document by its ID, including its embedding.
 
-        Args:
-            document_id (str): The document ID.
+        Parameters
+        ----------
+        document_id : str
+            The document ID.
 
         Returns
         -------
-            Document | None: The retrieved document with embedding, or None if
-                not found.
+        Document | None
+            The retrieved document with embedding, or `None` if not found.
         """
         await self.vector_store.astra_env.aensure_db_setup()
 

--- a/packages/langchain-graph-retriever/src/langchain_graph_retriever/adapters/base.py
+++ b/packages/langchain-graph-retriever/src/langchain_graph_retriever/adapters/base.py
@@ -29,12 +29,16 @@ class Adapter(Generic[StoreT], abc.ABC):
     This class provides a foundation for custom adapters, enabling consistent
     interaction with various vector store implementations.
 
-    Attributes
+    Parameters
     ----------
-        vector_store (T): The vector store instance.
-        use_normalized_metadata (bool): Indicates whether normalized metadata is used.
-        denormalized_path_delimiter (str): Delimiter for denormalized metadata keys.
-        denormalized_static_value (str): Value to use for denormalized metadata entries.
+    vector_store : T
+        The vector store instance.
+    use_normalized_metadata : bool
+        Indicates whether normalized metadata is used.
+    denormalized_path_delimiter : str
+        Delimiter for denormalized metadata keys.
+    denormalized_static_value : str
+        Value to use for denormalized metadata entries.
     """
 
     def __init__(
@@ -48,14 +52,16 @@ class Adapter(Generic[StoreT], abc.ABC):
         """
         Initialize the base adapter.
 
-        Args:
-            vector_store (T): The vector store instance.
-            use_normalized_metadata (bool): Indicates whether normalized
-                metadata is used.
-            denormalized_path_delimiter (str): Delimiter for denormalized
-                metadata keys.
-            denormalized_static_value (str): Value to use for denormalized
-                metadata entries.
+        Parameters
+        ----------
+        vector_store : T
+            The vector store instance.
+        use_normalized_metadata : bool
+            Indicates whether normalized metadata is used.
+        denormalized_path_delimiter : str
+            Delimiter for denormalized metadata keys.
+        denormalized_static_value : str
+            Value to use for denormalized metadata entries.
         """
         self.vector_store = vector_store
         self.use_normalized_metadata = use_normalized_metadata
@@ -76,23 +82,32 @@ class Adapter(Generic[StoreT], abc.ABC):
         filter: dict[str, str] | None = None,
         **kwargs: Any,
     ) -> tuple[list[float], list[Document]]:
-        """Return docs (with embeddings) most similar to the query.
+        """
+        Return docs (with embeddings) most similar to the query.
 
         Also returns the embedded query vector.
 
-        Args:
-            query: Input text.
-            k: Number of Documents to return. Defaults to 4.
-            filter: Filter on the metadata to apply.
-            **kwargs: Additional keyword arguments.
+        Parameters
+        ----------
+        query : str
+            Input text.
+        k : int, default 4
+            Number of Documents to return.
+        filter : dict[str, str], optional
+            Filter on the metadata to apply.
+        **kwargs : Any
+            Additional keyword arguments.
 
         Returns
         -------
-            A tuple of:
-                * The embedded query vector
-                * List of Documents most similar to the query vector.
-                  Documents should have their embedding added to
-                  their metadata under the METADATA_EMBEDDING_KEY key.
+        query_embedding : list[float]
+            The embedded query vector
+        documents : list[Document]
+            List of up to `k` documents most similar to the query
+            vector.
+
+            Documents should have their embedding added to the
+            metadata under the `METADATA_EMBEDDING_KEY` key.
         """
         query_embedding = self._safe_embedding.embed_query(text=query)
         docs = self.similarity_search_with_embedding_by_vector(
@@ -110,23 +125,32 @@ class Adapter(Generic[StoreT], abc.ABC):
         filter: dict[str, str] | None = None,
         **kwargs: Any,
     ) -> tuple[list[float], list[Document]]:
-        """Asynchronously return docs (with embeddings) most similar to the query.
+        """
+        Asynchronously return docs (with embeddings) most similar to the query.
 
         Also returns the embedded query vector.
 
-        Args:
-            query: Input text.
-            k: Number of Documents to return. Defaults to 4.
-            filter: Filter on the metadata to apply.
-            **kwargs: Additional keyword arguments.
+        Parameters
+        ----------
+        query : str
+            Input text.
+        k : int, default 4
+            Number of Documents to return.
+        filter : dict[str, str], optional
+            Filter on the metadata to apply.
+        **kwargs : Any
+            Additional keyword arguments.
 
         Returns
         -------
-            A tuple of:
-                * The embedded query vector
-                * List of Documents most similar to the query vector.
-                  Documents should have their embedding added to
-                  their metadata under the METADATA_EMBEDDING_KEY key.
+        query_embedding : list[float]
+            The embedded query vector
+        documents : list[Document]
+            List of up to `k` documents most similar to the query
+            vector.
+
+            Documents should have their embedding added to the
+            metadata under the `METADATA_EMBEDDING_KEY` key.
         """
         return await run_in_executor(
             None, self.similarity_search_with_embedding, query, k, filter, **kwargs
@@ -140,19 +164,27 @@ class Adapter(Generic[StoreT], abc.ABC):
         filter: dict[str, str] | None = None,
         **kwargs: Any,
     ) -> list[Document]:
-        """Return docs (with embeddings) most similar to the query vector.
+        """
+        Return docs (with embeddings) most similar to the query vector.
 
-        Args:
-            embedding: Embedding to look up documents similar to.
-            k: Number of Documents to return. Defaults to 4.
-            filter: Filter on the metadata to apply.
-            **kwargs: Additional keyword arguments.
+        Parameters
+        ----------
+        embedding : list[float]
+            Embedding to look up documents similar to.
+        k : int, default 4
+            Number of Documents to return.
+        filter : dict[str, str], optional
+            Filter on the metadata to apply.
+        **kwargs : Any
+            Additional keyword arguments.
 
         Returns
         -------
-            List of Documents most similar to the query vector. Documents should
-            have their embedding added to their metadata under the
-            METADATA_EMBEDDING_KEY key.
+        list[Document]
+            List of Documents most similar to the query vector.
+
+            Documents should have their embedding added to the
+            metadata under the `METADATA_EMBEDDING_KEY` key.
         """
 
     async def asimilarity_search_with_embedding_by_vector(
@@ -165,17 +197,24 @@ class Adapter(Generic[StoreT], abc.ABC):
         """
         Asynchronously return docs (with embeddings) most similar to the query vector.
 
-        Args:
-            embedding: Embedding to look up documents similar to.
-            k: Number of Documents to return. Defaults to 4.
-            filter: Filter on the metadata to apply.
-            **kwargs: Additional keyword arguments.
+        Parameters
+        ----------
+        embedding : list[float]
+            Embedding to look up documents similar to.
+        k : int, default 4
+            Number of Documents to return.
+        filter : dict[str, str], optional
+            Filter on the metadata to apply.
+        **kwargs : Any
+            Additional keyword arguments.
 
         Returns
         -------
-            List of Documents most similar to the query vector. Documents should
-            have their embedding added to their metadata under the
-            METADATA_EMBEDDING_KEY key.
+        list[Document]
+            List of Documents most similar to the query vector.
+
+            Documents should have their embedding added to the
+            metadata under the `METADATA_EMBEDDING_KEY` key.
         """
         return await run_in_executor(
             None,
@@ -193,7 +232,8 @@ class Adapter(Generic[StoreT], abc.ABC):
         /,
         **kwargs: Any,
     ) -> list[Document]:
-        """Get documents by id.
+        """
+        Get documents by id.
 
         Fewer documents may be returned than requested if some IDs are not found
         or if there are duplicated IDs. This method should **NOT** raise
@@ -203,13 +243,17 @@ class Adapter(Generic[StoreT], abc.ABC):
         the order of the input IDs. Instead, users should rely on the ID field
         of the returned documents.
 
-        Args:
-            ids: List of IDs to get.
-            kwargs: Additional keyword arguments. These are up to the implementation.
+        Parameters
+        ----------
+        ids : Sequence[str]
+            List of IDs to get.
+        **kwargs : Any
+            Additional keyword arguments. These are up to the implementation.
 
         Returns
         -------
-            List[Document]: List of documents that were found.
+        list[Document]
+            List of documents that were found.
         """
 
     async def aget(
@@ -218,7 +262,8 @@ class Adapter(Generic[StoreT], abc.ABC):
         /,
         **kwargs: Any,
     ) -> list[Document]:
-        """Asynchronously get documents by id.
+        """
+        Asynchronously get documents by id.
 
         Fewer documents may be returned than requested if some IDs are not found
         or if there are duplicated IDs. This method should **NOT** raise
@@ -228,13 +273,17 @@ class Adapter(Generic[StoreT], abc.ABC):
         the order of the input IDs. Instead, users should rely on the ID field
         of the returned documents.
 
-        Args:
-            ids: List of IDs to get.
-            kwargs: Additional keyword arguments. These are up to the implementation.
+        Parameters
+        ----------
+        ids : Sequence[str]
+            List of IDs to get.
+        **kwargs : Any
+            Additional keyword arguments. These are up to the implementation.
 
         Returns
         -------
-            List[Document]: List of documents that were found.
+        list[Document]
+            List of documents that were found.
         """
         return await run_in_executor(
             None,
@@ -250,22 +299,29 @@ class Adapter(Generic[StoreT], abc.ABC):
         filter: dict[str, Any] | None,
         **kwargs: Any,
     ) -> Iterable[Document]:
-        """Return the docs with incoming edges from any of the given edges.
+        """
+        Return the docs with incoming edges from any of the given edges.
 
-        Args:
-            outgoing_edges: The edges to look for.
-            strategy: The traversal strategy being used.
-            filter: Optional metadata to filter the results.
-            kwargs: Keyword arguments to pass to the similarity search.
+        Parameters
+        ----------
+        outgoing_edges : set[Edge]
+            The edges to look for.
+        strategy : Strategy
+            The traversal strategy being used.
+        filter : dict[str, Any], optional
+            Optional metadata to filter the results.
+        **kwargs : Any
+            Keyword arguments to pass to the similarity search.
 
         Returns
         -------
+        Iterable[Document]
             Iterable of adjacent nodes.
         """
         results: list[Document] = []
         for outgoing_edge in outgoing_edges:
             docs = self.similarity_search_with_embedding_by_vector(
-                embedding=strategy.query_embedding,
+                embedding=strategy._query_embedding,
                 k=strategy.adjacent_k,
                 filter=self._get_metadata_filter(
                     base_filter=filter, edge=outgoing_edge
@@ -280,7 +336,7 @@ class Adapter(Generic[StoreT], abc.ABC):
                 # caught as well. This could *maybe* be handled differently if
                 # we know keys that were always denormalized.
                 docs = self.similarity_search_with_embedding_by_vector(
-                    embedding=strategy.query_embedding,
+                    embedding=strategy._query_embedding,
                     k=strategy.adjacent_k,
                     filter=self._get_metadata_filter(
                         base_filter=filter, edge=outgoing_edge, denormalize_edge=True
@@ -300,19 +356,25 @@ class Adapter(Generic[StoreT], abc.ABC):
         """
         Asynchronously return the docs with incoming edges from any of the given edges.
 
-        Args:
-            outgoing_edges: The edges to look for.
-            strategy: The traversal strategy being used.
-            filter: Optional metadata to filter the results.
-            kwargs: Keyword arguments to pass to the similarity search.
+        Parameters
+        ----------
+        outgoing_edges : set[Edge]
+            The edges to look for.
+        strategy : Strategy
+            The traversal strategy being used.
+        filter : dict[str, Any], optional
+            Optional metadata to filter the results.
+        **kwargs : Any
+            Keyword arguments to pass to the similarity search.
 
         Returns
         -------
+        Iterable[Document]
             Iterable of adjacent nodes.
         """
         tasks = [
             self.asimilarity_search_with_embedding_by_vector(
-                embedding=strategy.query_embedding,
+                embedding=strategy._query_embedding,
                 k=strategy.adjacent_k,
                 filter=self._get_metadata_filter(
                     base_filter=filter, edge=outgoing_edge
@@ -330,7 +392,7 @@ class Adapter(Generic[StoreT], abc.ABC):
             tasks.extend(
                 [
                     self.asimilarity_search_with_embedding_by_vector(
-                        embedding=strategy.query_embedding,
+                        embedding=strategy._query_embedding,
                         k=strategy.adjacent_k,
                         filter=self._get_metadata_filter(
                             base_filter=filter,
@@ -355,16 +417,25 @@ class Adapter(Generic[StoreT], abc.ABC):
         edge: Edge | None = None,
         denormalize_edge: bool = False,
     ) -> dict[str, Any]:
-        """Build a metadata filter to search for documents.
+        """
+        Return a filter for the `base_filter` and incoming edges from `edge`.
 
-        Args:
-            base_filter: Any metadata that should be used for hybrid search
-            edge: An optional outgoing edge to add to the search
-            denormalize_edge: Whether edges should be denormalized.
+        Parameters
+        ----------
+        base_filter : dict[str, Any]
+            Any base metadata filter that should be used for search.
+            Generally corresponds to the user specified filters for the entire
+            traversal. Should be combined with the filters necessary to support
+            nodes with an *incoming* edge matching `edge`.
+        edge : Edge, optional
+            An optional edge which should be added to the filter.
+        denormalize_edge : bool, default False
+            Whether edges should be denormalized.
 
         Returns
         -------
-        The metadata dictionary to use for the given filter.
+        dict[str, Any]
+            The metadata dictionary to use for the given filter.
         """
         metadata_filter = {**(base_filter or {})}
         if edge is None:

--- a/packages/langchain-graph-retriever/src/langchain_graph_retriever/adapters/cassandra.py
+++ b/packages/langchain-graph-retriever/src/langchain_graph_retriever/adapters/cassandra.py
@@ -20,10 +20,14 @@ class CassandraAdapter(Adapter[Cassandra]):
     This class integrates the Cassandra vector store with the graph retriever system,
     providing functionality for similarity search and document retrieval.
 
-    Args:
-        vector_store (Cassandra): The Cassandra vector store instance.
-        denormalized_path_delimiter (str): Delimiter for denormalized metadata keys.
-        denormalized_static_value (str): Value to use for denormalized metadata entries.
+    Parameters
+    ----------
+    vector_store : Cassandra
+        The Cassandra vector store instance.
+    denormalized_path_delimiter : str, default "."
+        Delimiter for denormalized metadata keys.
+    denormalized_static_value : str, default "$"
+        Value to use for denormalized metadata entries.
     """
 
     def __init__(
@@ -68,21 +72,6 @@ class CassandraAdapter(Adapter[Cassandra]):
         filter: dict[str, str] | None = None,
         body_search: str | list[str] | None = None,
     ) -> list[tuple[Document, list[float], str]]:
-        """
-        Return documents most similar to the embedding vector, including their IDs.
-
-        Args:
-            embedding (list[float]): The query embedding vector.
-            k (int): Number of top documents to retrieve. Defaults to 4.
-            filter (dict[str, str] | None): Metadata filter to apply.
-            body_search (str | list[str] | None): Textual search terms. Supported only
-                by Astra DB.
-
-        Returns
-        -------
-            list[tuple[Document, list[float], str]]: List of tuples containing
-                documents, embeddings, and IDs.
-        """
         kwargs: dict[str, Any] = {}
         if filter is not None:
             kwargs["metadata"] = filter
@@ -152,16 +141,6 @@ class CassandraAdapter(Adapter[Cassandra]):
         return docs
 
     def _get_by_document_id(self, id: str) -> Document | None:
-        """
-        Retrieve a document by its ID.
-
-        Args:
-            id (str): The document ID.
-
-        Returns
-        -------
-            Document | None: The retrieved document, or None if not found.
-        """
         row = self.vector_store.table.get(row_id=id)
         if row is None:
             return None
@@ -184,16 +163,6 @@ class CassandraAdapter(Adapter[Cassandra]):
         return docs
 
     async def _aget_by_document_id(self, id: str) -> Document | None:
-        """
-        Asynchronously retrieve a document by its ID.
-
-        Args:
-            id (str): The document ID.
-
-        Returns
-        -------
-            Document | None: The retrieved document, or None if not found.
-        """
         row = await self.vector_store.table.aget(row_id=id)
         if row is None:
             return None

--- a/packages/langchain-graph-retriever/src/langchain_graph_retriever/adapters/chroma.py
+++ b/packages/langchain-graph-retriever/src/langchain_graph_retriever/adapters/chroma.py
@@ -21,10 +21,14 @@ class ChromaAdapter(Adapter[Chroma]):
     This adapter integrates the Chroma vector store with the graph retriever system,
     allowing for similarity search and document retrieval.
 
-    Args:
-        vector_store (Chroma): The Chroma vector store instance.
-        denormalized_path_delimiter (str): Delimiter for denormalized metadata keys.
-        denormalized_static_value (str): Value to use for denormalized metadata entries.
+    Parameters
+    ----------
+    vector_store : Chroma
+        The Chroma vector store instance.
+    denormalized_path_delimiter : str, default "."
+        Delimiter for denormalized metadata keys.
+    denormalized_static_value : str, default "$"
+        Value to use for denormalized metadata entries.
     """
 
     def __init__(
@@ -93,7 +97,6 @@ class ChromaAdapter(Adapter[Chroma]):
 
     @override
     def get(self, ids: Sequence[str], /, **kwargs: Any) -> list[Document]:
-        """Get documents by id."""
         results = self.vector_store.get(
             ids=list(ids), include=["embeddings", "metadatas", "documents"], **kwargs
         )

--- a/packages/langchain-graph-retriever/src/langchain_graph_retriever/adapters/in_memory.py
+++ b/packages/langchain-graph-retriever/src/langchain_graph_retriever/adapters/in_memory.py
@@ -18,11 +18,16 @@ class InMemoryAdapter(Adapter[InMemoryVectorStore]):
     This adapter integrates the in-memory vector store with the graph retriever system,
     enabling similarity search and document retrieval.
 
-    Args:
-        vector_store (InMemoryVectorStore): The in-memory vector store instance.
-        use_normalized_metadata (bool): Indicates whether normalized metadata is used.
-        denormalized_path_delimiter (str): Delimiter for denormalized metadata keys.
-        denormalized_static_value (str): Value to use for denormalized metadata entries.
+    Parameters
+    ----------
+    vector_store : InMemoryVectorStore
+        The in-memory vector store instance.
+    use_normalized_metadata : bool, default False
+        Indicates whether normalized metadata is used.
+    denormalized_path_delimiter : str, default "."
+        Delimiter for denormalized metadata keys.
+    denormalized_static_value : str, default "$"
+        Value to use for denormalized metadata entries.
     """
 
     def __init__(
@@ -55,13 +60,17 @@ class InMemoryAdapter(Adapter[InMemoryVectorStore]):
         """
         Add embeddings to the metadata of documents.
 
-        Args:
-            docs (Sequence[Document]): List of documents.
-            embeddings (list[list[float]]): Corresponding embeddings.
+        Parameters
+        ----------
+        docs : Sequence[Document]
+            List of documents.
+        embeddings : list[list[float]])
+            Corresponding embeddings.
 
         Returns
         -------
-            list[Document]: Documents with updated metadata containing embeddings.
+        list[Document]
+            Documents with updated metadata containing embeddings.
         """
         return [
             Document(
@@ -111,15 +120,20 @@ class InMemoryAdapter(Adapter[InMemoryVectorStore]):
         """
         Check if a key-value pair exists or if the value is contained in the metadata.
 
-        Args:
-            key (str): Metadata key to look for.
-            value (Any): Value to check for equality or containment.
-            metadata (dict[str, Any]): Metadata dictionary to inspect.
+        Parameters
+        ----------
+        key : str
+            Metadata key to look for.
+        value : Any
+            Value to check for equality or containment.
+        metadata : dict[str, Any]
+            Metadata dictionary to inspect.
 
         Returns
         -------
-            bool: True if the key-value pair exists or if the value is contained,
-            False otherwise.
+        bool
+            True if and only if `metadata[key] == value` or `metadata[key]` is a
+            list containing `value`.
         """
         actual = metadata.get(key, SENTINEL)
         if actual == value:
@@ -141,14 +155,15 @@ class InMemoryAdapter(Adapter[InMemoryVectorStore]):
         """
         Create a filter function based on a metadata dictionary.
 
-        Args:
-            filter_dict (dict[str, str] | None): Dictionary specifying the filter
-                criteria.
+        Parameters
+        ----------
+        filter_dict : dict[str, str], optional
+            Dictionary specifying the filter criteria.
 
         Returns
         -------
-            Callable[[Document], bool]: A function that determines if a document matches
-            the filter criteria.
+        Callable[[Document], bool]
+            A function that determines if a document matches the filter criteria.
         """
         if filter_dict is None:
             return lambda _doc: True

--- a/packages/langchain-graph-retriever/src/langchain_graph_retriever/adapters/inference.py
+++ b/packages/langchain-graph-retriever/src/langchain_graph_retriever/adapters/inference.py
@@ -49,17 +49,20 @@ def infer_adapter(store: Adapter | VectorStore) -> Adapter:
     This function identifies the correct adapter based on the vector store type
     and instantiates it with the provided arguments.
 
-    Args:
-        vector_store (VectorStore): The vector store instance.
-        **kwargs: Additional keyword arguments for the adapter initialization.
+    Parameters
+    ----------
+    vector_store : VectorStore
+        The vector store instance.
 
     Returns
     -------
-        Any: The initialized adapter for the given vector store.
+    Any
+        The initialized adapter for the given vector store.
 
     Raises
     ------
-        ValueError: If the vector store type is not recognized.
+    ValueError
+        If the vector store type is not recognized.
     """
     if isinstance(store, Adapter):
         return store

--- a/packages/langchain-graph-retriever/src/langchain_graph_retriever/adapters/open_search.py
+++ b/packages/langchain-graph-retriever/src/langchain_graph_retriever/adapters/open_search.py
@@ -20,8 +20,10 @@ class OpenSearchAdapter(Adapter[OpenSearchVectorSearch]):
     This adapter enables similarity search and document retrieval using an
     OpenSearch vector store. It supports both "lucene" and "faiss" engines.
 
-    Args:
-        vector_store (OpenSearchVectorSearch): The OpenSearch vector store instance.
+    Parameters
+    ----------
+    vector_store  : OpenSearchVectorSearch
+        The OpenSearch vector store instance.
     """
 
     def __init__(self, vector_store: OpenSearchVectorSearch):
@@ -40,12 +42,15 @@ class OpenSearchAdapter(Adapter[OpenSearchVectorSearch]):
         """
         Build a filter query for OpenSearch based on metadata.
 
-        Args:
-            filter (dict[str, str] | None): Metadata filter to apply.
+        Parameters
+        ----------
+        filter : dict[str, str], optional
+            Metadata filter to apply.
 
         Returns
         -------
-            list[dict[str, Any]] | None: Filter query for OpenSearch.
+        list[dict[str, Any]] | None
+            Filter query for OpenSearch.
         """
         if filter is None:
             return None

--- a/packages/langchain-graph-retriever/src/langchain_graph_retriever/document_graph.py
+++ b/packages/langchain-graph-retriever/src/langchain_graph_retriever/document_graph.py
@@ -8,18 +8,21 @@ from langchain_core.documents import Document
 
 
 def _best_communities(graph: nx.DiGraph) -> list[list[str]]:
-    """Compute the best communities in a directed graph.
+    """
+    Compute the best communities in a directed graph.
 
     This function iteratively applies the Girvan-Newman algorithm to partition the
     graph into communities. It continues until the modularity no longer improves.
 
-    Args:
-        graph (nx.DiGraph): The directed graph to analyze.
+    Parameters
+    ----------
+    graph : nx.DiGraph
+        The directed graph to analyze.
 
     Returns
     -------
-        list[list[str]]: A list of communities, where each community is a list of
-        node IDs.
+    list[list[str]]
+        A list of communities, where each community is a list of node IDs.
     """
     # TODO: Also continue running until the size of communities is below
     # a specified threshold?
@@ -37,19 +40,24 @@ def _best_communities(graph: nx.DiGraph) -> list[list[str]]:
 
 
 def _get_md_values(metadata: dict[str, Any], field: str) -> Iterable[Any]:
-    """Retrieve metadata values for a specific field.
+    """
+    Retrieve metadata values for a specific field.
 
     This function extracts values from the metadata dictionary for the given field,
     handling cases where the value is a single string, a list, or another iterable.
 
-    Args:
-        metadata (dict[str, Any]): The metadata dictionary.
-        field (str): The field to extract values from.
+    Parameters
+    ----------
+    metadata : dict[str, Any]
+        The metadata dictionary.
+    field : str
+        The field to extract values from.
 
     Returns
     -------
-        Iterable[Any]: A list of values for the specified field. If no values are
-        found, an empty list is returned.
+    Iterable[Any]
+        A list of values for the specified field. If no values are found, an
+        empty list is returned.
     """
     value = metadata.get(field, None)
     if value is None:
@@ -69,23 +77,27 @@ def create_graph(
     *,
     edges: Iterable[str | tuple[str, str]],
 ) -> nx.DiGraph:
-    """Create a directed graph from a sequence of documents.
+    """
+    Create a directed graph from a sequence of documents.
 
     This function constructs a directed graph where each document is a node, and
     edges are defined based on relationships in the document metadata.
 
-    Args:
-        documents (Sequence[Document]): A sequence of documents to add as nodes.
-        edges (Iterable[str | tuple[str, str]]): Definitions of edges to use for
-            creating the graph. Each edge can be:
-            - A string representing a single metadata field (interpreted as both
-              `from` and `to`).
-            - A tuple of two strings (`from_field`, `to_field`) specifying the
-              relationship.
+    Parameters
+    ----------
+    documents : Sequence[Document]
+        A sequence of documents to add as nodes.
+    edges : Iterable[str | tuple[str, str]])
+        Definitions of edges to use for creating the graph. Each edge can be:
+        - A string representing a single metadata field (interpreted as both
+            `from` and `to`).
+        - A tuple of two strings (`from_field`, `to_field`) specifying the
+            relationship.
 
     Returns
     -------
-        nx.DiGraph: The created directed graph with documents as nodes and metadata
+    nx.DiGraph
+        The created directed graph with documents as nodes and metadata
         relationships as edges.
     """
     graph = nx.DiGraph()
@@ -132,18 +144,21 @@ def create_graph(
 
 
 def group_by_community(graph: nx.DiGraph) -> list[list[Document]]:
-    """Group documents by community inferred from the graph's structure.
+    """
+    Group documents by community inferred from the graph's structure.
 
     This function partitions the graph into communities using the Girvan-Newman
     algorithm and groups documents based on their community memberships.
 
-    Args:
-        graph (nx.DiGraph): The directed graph of documents.
+    Paramaters
+    ----------
+    graph : nx.DiGraph
+        The directed graph of documents.
 
     Returns
     -------
-        list[list[Document]]: A list of communities, where each community is a list
-        of documents.
+    list[list[Document]]
+        A list of communities, where each community is a list of documents.
     """
     # Find communities and output documents grouped by community.
     communities = _best_communities(graph)

--- a/packages/langchain-graph-retriever/src/langchain_graph_retriever/document_transformers/gliner_entity_extractor.py
+++ b/packages/langchain-graph-retriever/src/langchain_graph_retriever/document_transformers/gliner_entity_extractor.py
@@ -1,11 +1,12 @@
 from collections.abc import Sequence
-from typing import Any
+from typing import Any, override
 
 from langchain_core.documents import BaseDocumentTransformer, Document
 
 
 class GLiNEREntityExtractor(BaseDocumentTransformer):
-    """Add metadata to documents about named entities using `GLiNER`_.
+    """
+    Add metadata to documents about named entities using `GLiNER`_.
 
     `GLiNER`_ is a Named Entity Recognition (NER) model capable of identifying any
     entity type using a bidirectional transformer encoder (BERT-like).
@@ -22,7 +23,7 @@ class GLiNEREntityExtractor(BaseDocumentTransformer):
 
         pip install -q langchain_community bs4 gliner
 
-    Example:
+    Example
     -------
     We load the ``state_of_the_union.txt`` file, chunk it, then for each chunk we
     add named entities to the metadata.
@@ -50,11 +51,18 @@ class GLiNEREntityExtractor(BaseDocumentTransformer):
 
         {'source': 'https://raw.githubusercontent.com/hwchase17/chat-your-data/master/state_of_the_union.txt', 'person': ['president zelenskyy', 'vladimir putin']}
 
-    Args:
-        labels: List of entity kinds to extract.
-        batch_size: The number of documents to process in each batch (default ``8``)
-        metadata_key_prefix: A prefix to add to metadata keys outputted by the extractor (default ``""``)
-        model: The GLiNER model to use. (default ``urchade/gliner_mediumv2.1``)
+    Parameters
+    ----------
+    labels : list[str]
+        List of entity kinds to extract.
+    batch_size : int, default 8
+        The number of documents to process in each batch.
+    metadata_key_prefix : str, default ""
+        A prefix to add to metadata keys outputted by the extractor.
+        This will be prepended to the label, with the value (or values) holding the
+        generated keywords for that entity kind.
+    model : str, default "urchade/gliner_mediumv2.1"
+        The GLiNER model to use.
 
     """  # noqa: E501
 
@@ -81,16 +89,10 @@ class GLiNEREntityExtractor(BaseDocumentTransformer):
         self._labels = labels
         self.metadata_key_prefix = metadata_key_prefix
 
+    @override
     def transform_documents(
         self, documents: Sequence[Document], **kwargs: Any
     ) -> Sequence[Document]:
-        """Extract named entities from documents using GLiNER.
-
-        Args:
-            documents: The sequence of documents to transform
-            kwargs: Keyword arguments to pass to GLiNER. See: https://github.com/urchade/GLiNER/blob/v0.2.13/gliner/model.py#L419-L421
-
-        """
         for i in range(0, len(documents), self._batch_size):
             batch = documents[i : i + self._batch_size]
             texts = [item.page_content for item in batch]

--- a/packages/langchain-graph-retriever/src/langchain_graph_retriever/document_transformers/html_hyperlink_extractor.py
+++ b/packages/langchain-graph-retriever/src/langchain_graph_retriever/document_transformers/html_hyperlink_extractor.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 from urllib.parse import urldefrag, urljoin, urlparse
 
 from langchain_core._api import beta
@@ -14,7 +14,8 @@ if TYPE_CHECKING:
 
 @beta()
 class HtmlHyperlinkExtractor(BaseDocumentTransformer):
-    """Extract hyperlinks from HTML content.
+    """
+    Extract hyperlinks from HTML content.
 
     Expects each document to contain its URL in its metadata.
 
@@ -184,10 +185,15 @@ class HtmlHyperlinkExtractor(BaseDocumentTransformer):
 
         store = CassandraGraphVectorStore.from_documents(documents=documents, embedding=...)
 
-    Args:
-        kind: The kind of edge to extract. Defaults to ``hyperlink``.
-        drop_fragments: Whether fragments in URLs and links should be
-            dropped. Defaults to ``True``.
+    Parameters
+    ----------
+        url_metadata_key : str, default "url"
+            The metadata field containing the URL of the document. Must be set
+            before transforming. Needed to resolve relative paths.
+        metadata_key : str, default "hyperlink"
+            The metadata field to populate with documents linked from this content.
+        drop_fragments : bool, default True
+            Whether fragments in URLs and links should be dropped.
 
     """  # noqa: E501
 
@@ -248,16 +254,10 @@ class HtmlHyperlinkExtractor(BaseDocumentTransformer):
 
         return list(urls)
 
+    @override
     def transform_documents(
         self, documents: Sequence[Document], **kwargs: Any
     ) -> Sequence[Document]:
-        """Extract hyperlinks from html documents using BeautifulSoup4.
-
-        Args:
-            documents: The documents to transform.
-            kwargs: Arguments to pass through to the BeautifulSoup parser.
-
-        """
         for document in documents:
             if self._url_metadata_key not in document.metadata:
                 msg = (

--- a/packages/langchain-graph-retriever/src/langchain_graph_retriever/document_transformers/keybert_keyword_extractor.py
+++ b/packages/langchain-graph-retriever/src/langchain_graph_retriever/document_transformers/keybert_keyword_extractor.py
@@ -1,11 +1,12 @@
 from collections.abc import Sequence
-from typing import Any
+from typing import Any, override
 
 from langchain_core.documents import BaseDocumentTransformer, Document
 
 
 class KeybertKeywordExtractor(BaseDocumentTransformer):
-    """Add metadata to documents about keywords using `KeyBERT <https://maartengr.github.io/KeyBERT/>`_.
+    """
+    Add metadata to documents about keywords using `KeyBERT <https://maartengr.github.io/KeyBERT/>`_.
 
     KeyBERT is a minimal and easy-to-use keyword extraction technique that
     leverages BERT embeddings to create keywords and keyphrases that are most
@@ -26,7 +27,7 @@ class KeybertKeywordExtractor(BaseDocumentTransformer):
 
         pip install -q langchain_community bs4 keybert
 
-    Example:
+    Example
     -------
     We load the ``state_of_the_union.txt`` file, chunk it, then for each chunk we
     add keywords to the metadata.
@@ -54,11 +55,14 @@ class KeybertKeywordExtractor(BaseDocumentTransformer):
 
         {'source': 'https://raw.githubusercontent.com/hwchase17/chat-your-data/master/state_of_the_union.txt', 'keywords': ['putin', 'vladimir', 'ukrainian', 'russia', 'ukraine']}
 
-    Args:
-        batch_size: The number of documents to process in each batch (default ``8``)
-        metadata_key: The name of the key used in the metadata output (default ``keywords``)
-        model: The KeyBERT model to use. (default ``all-MiniLM-L6-v2``)
-
+    Parameters
+    ----------
+    batch_size : int, default 8
+        The number of documents to process in each batch.
+    metadata_key : str, default "keywords"
+        The name of the key used in the metadata output.
+    model : str, default "all-MiniLM-L6-v2"
+        The KeyBERT model to use.
     """  # noqa: E501
 
     def __init__(
@@ -81,16 +85,10 @@ class KeybertKeywordExtractor(BaseDocumentTransformer):
         self._batch_size = batch_size
         self._metadata_key = metadata_key
 
+    @override
     def transform_documents(
         self, documents: Sequence[Document], **kwargs: Any
     ) -> Sequence[Document]:
-        """Add keyword metadata to documents using KeyBERT.
-
-        Args:
-            documents: The sequence of documents to transform
-            kwargs: Keyword arguments to pass to KeyBERT. See: https://maartengr.github.io/KeyBERT/api/keybert.html#keybert._model.KeyBERT.extract_keywords
-
-        """
         for i in range(0, len(documents), self._batch_size):
             batch = documents[i : i + self._batch_size]
             texts = [item.page_content for item in batch]

--- a/packages/langchain-graph-retriever/src/langchain_graph_retriever/document_transformers/metadata_denormalizer.py
+++ b/packages/langchain-graph-retriever/src/langchain_graph_retriever/document_transformers/metadata_denormalizer.py
@@ -1,13 +1,14 @@
 """Denormalizer for sequence-based metadata fields."""
 
 from collections.abc import Sequence
-from typing import Any
+from typing import Any, override
 
 from langchain_core.documents import BaseDocumentTransformer, Document
 
 
 class MetadataDenormalizer(BaseDocumentTransformer):
-    """Denormalizes sequence-based metadata fields.
+    """
+    Denormalizes sequence-based metadata fields.
 
     Certain vector stores do not support storing or searching on metadata fields
     with sequence-based values. This transformer converts sequence-based fields
@@ -39,11 +40,15 @@ class MetadataDenormalizer(BaseDocumentTransformer):
 
         {'place.berlin': True, 'place.paris': True, 'topic.weather': True}
 
-    Args:
-        keys: A set of metadata keys to denormalize. If empty, all
-            sequence-based fields will be denormalized.
-        path_delimiter: The path delimiter to use when building denormalized keys.
-        static_value: The value to set on each denormalized key.
+    Parameters
+    ----------
+    keys : set[str], optional:
+        A set of metadata keys to denormalize.
+        If empty, all sequence-based fields will be denormalized.
+    path_delimiter : str, default "."
+        The path delimiter to use when building denormalized keys.
+    static_value : str, default "$"
+        The value to set on each denormalized key.
 
     """  # noqa: E501
 
@@ -54,24 +59,14 @@ class MetadataDenormalizer(BaseDocumentTransformer):
         path_delimiter: str = ".",
         static_value: Any = "$",
     ):
-        """Create a metadata denormalizing transformation.
-
-        Args:
-            keys: The set of keys to denormalize. If empty (default), all metadata
-                entries containing a collection will be denormalized.
-            path_delimiter: The delimiter to use in the denormalized key between the
-                original key and the item value.
-            static_value: The value to use the denormalized metadata entries.
-
-        """
         self.keys = keys
         self.path_delimiter = path_delimiter
         self.static_value = static_value
 
+    @override
     def transform_documents(
         self, documents: Sequence[Document], **kwargs: Any
     ) -> Sequence[Document]:
-        """Denormalizes sequence-based metadata fields."""
         transformed_docs = []
         for document in documents:
             new_doc = Document(id=document.id, page_content=document.page_content)

--- a/packages/langchain-graph-retriever/src/langchain_graph_retriever/edge_helper.py
+++ b/packages/langchain-graph-retriever/src/langchain_graph_retriever/edge_helper.py
@@ -14,7 +14,8 @@ SENTINEL = object()
 
 
 class Edge(NamedTuple):
-    """Represents an edge to all nodes with the given key/value pair.
+    """
+    Represents an edge to all nodes with the given key/value pair.
 
     Attributes
     ----------
@@ -29,7 +30,8 @@ class Edge(NamedTuple):
 
 
 class EdgeHelper:
-    """Helper for extracting and encoding edges in metadata.
+    """
+    Helper for extracting and encoding edges in metadata.
 
     This class provides tools to extract incoming and outgoing edges from document
     metadata and normalize metadata where needed. Both incoming and outgoing edges
@@ -104,23 +106,27 @@ class EdgeHelper:
         warn_normalized: bool = False,
         incoming: bool = False,
     ) -> set[Edge]:
-        """Extract edges from the metadata based on declared edge definitions.
+        """
+        Extract edges from the metadata based on declared edge definitions.
 
-        Args:
-            metadata (dict[str, Any]): The metadata dictionary to process.
-            warn_normalized (bool, optional): If True, warnings are issued for
-                normalized metadata. Defaults to False.
-            incoming (bool, optional): If True, extracts edges for incoming
-                relationships. Defaults to False.
+        Parameters
+        ----------
+        metadata :dict[str, Any]
+            The metadata dictionary to process.
+        warn_normalized : bool, default False
+            If True, warnings are issued for normalized metadata.
+        incoming : bool, default False
+            If True, extracts edges for incoming relationships.
 
         Returns
         -------
-            set[Edge]: A set of edges extracted from the metadata.
+        set[Edge]
+            A set of edges extracted from the metadata.
 
         Notes
         -----
-            - Handles both simple (key-value) and iterable metadata fields.
-            - Issues warnings for unsupported or unexpected values.
+        - Handles both simple (key-value) and iterable metadata fields.
+        - Issues warnings for unsupported or unexpected values.
         """
         edges = set()
         for source_key, target_key in self.edges:
@@ -150,20 +156,23 @@ class EdgeHelper:
     def _normalize_metadata(
         self, denormalized_metadata: dict[str, Any]
     ) -> dict[str, Any]:
-        """Normalize metadata by extracting key-value pairs based on the delimiter.
+        """
+        Normalize metadata by extracting key-value pairs based on the delimiter.
 
-        Args:
-            denormalized_metadata (dict[str, Any]): The denormalized metadata
-                dictionary.
+        Parameters
+        ----------
+        denormalized_metadata : dict[str, Any]
+            The denormalized metadata dictionary.
 
         Returns
         -------
-            dict[str, Any]: A dictionary containing normalized key-value pairs.
+        dict[str, Any]
+            A dictionary containing normalized key-value pairs.
 
         Notes
         -----
-            - Only processes keys with the `denormalized_static_value`.
-            - Skips items that cannot be compared or are invalid.
+        - Only processes keys with the `denormalized_static_value`.
+        - Skips items that cannot be compared or are invalid.
         """
         normalized: dict[str, Any] = {}
         for key, value in denormalized_metadata.items():
@@ -182,20 +191,24 @@ class EdgeHelper:
     def get_incoming_outgoing(
         self, metadata: dict[str, Any]
     ) -> tuple[set[Edge], set[Edge]]:
-        """Extract incoming and outgoing edges from metadata.
+        """
+        Extract incoming and outgoing edges from metadata.
 
         This method retrieves edges based on the declared edge definitions, taking
         into account whether normalized metadata is used. It combines normalized
         and denormalized edge data as needed.
 
-        Args:
-            metadata (dict[str, Any]): The metadata dictionary to extract edges from.
+        Parameters
+        ----------
+        metadata : dict[str, Any]
+            The metadata dictionary to extract edges from.
 
         Returns
         -------
-            tuple[set[Edge], set[Edge]]: A tuple containing:
-                - Incoming edges as a set of `Edge` objects.
-                - Outgoing edges as a set of `Edge` objects.
+        incoming : set[Edge]
+            Incoming edges as a set of `Edge` objects.
+        outgoing : set[Edge]
+            Outgoing edges as a set of `Edge` objects.
         """
         warn_normalized = not self.use_normalized_metadata
         outgoing_edges = self._edges_from_dict(

--- a/packages/langchain-graph-retriever/src/langchain_graph_retriever/graph_retriever.py
+++ b/packages/langchain-graph-retriever/src/langchain_graph_retriever/graph_retriever.py
@@ -21,7 +21,8 @@ from .strategies import Eager, Strategy
 
 # this class uses pydantic, so store must be provided at init time.
 class GraphRetriever(BaseRetriever):
-    """Retriever combining vector search and graph traversal.
+    """
+    Retriever combining vector search and graph traversal.
 
     The `GraphRetriever` class performs retrieval by first using vector search to find
     relevant documents, and then applying graph traversal to explore connected
@@ -34,9 +35,10 @@ class GraphRetriever(BaseRetriever):
         The vector store or adapter used for document retrieval.
     edges : list[str | tuple[str, str]]
         Definitions of edges used for graph traversal.
-    strategy : Strategy
-        The traversal strategy to use. Defaults to an `Eager`
-        (breadth-first) strategy.
+    strategy : Strategy, default Eager()
+        The traversal strategy to use.
+        Defaults to an `Eager` (breadth-first) strategy which explores
+        the top `adjacent_k` for each edge.
 
     Attributes
     ----------
@@ -58,7 +60,8 @@ class GraphRetriever(BaseRetriever):
     # Move the `k` extra argument (if any) to the strategy.
     @model_validator(mode="after")
     def apply_extra(self) -> Self:
-        """Apply extra configuration to the traversal strategy.
+        """
+        Apply extra configuration to the traversal strpategy.
 
         This method captures additional fields provided in `model_extra` and applies
         them to the current traversal strategy. Any extra fields are cleared after
@@ -66,7 +69,8 @@ class GraphRetriever(BaseRetriever):
 
         Returns
         -------
-            Self: The updated `GraphRetriever` instance.
+        Self
+            The updated `GraphRetriever` instance.
         """
         if self.model_extra:
             self.strategy = self.strategy.model_validate(
@@ -78,15 +82,18 @@ class GraphRetriever(BaseRetriever):
     def _edge_helper(
         self, edges: list[str | tuple[str, str]] | None = None
     ) -> EdgeHelper:
-        """Create an `EdgeHelper` instance for managing edges during traversal.
+        """
+        Create an `EdgeHelper` instance for managing edges during traversal.
 
-        Args:
-            edges (list[str | tuple[str, str]] | None): Optional edge definitions.
-                If not provided, uses the default edge definitions from the retriever.
+        Parameters
+        ----------
+        edges : list[str | tuple[str, str]], optional
+            Overridden edge definitions from the invocation.
 
         Returns
         -------
-            EdgeHelper: An instance of `EdgeHelper` configured with the specified edges.
+        EdgeHelper
+            An instance of `EdgeHelper` configured with the specified edges.
         """
         return EdgeHelper(
             edges=self.edges if edges is None else edges,
@@ -111,25 +118,32 @@ class GraphRetriever(BaseRetriever):
         store_kwargs: dict[str, Any] = {},
         **kwargs: Any,
     ) -> list[Document]:
-        """Retrieve doc nodes using graph traversal and similarity search.
+        """
+        Retrieve doc nodes using graph traversal and similarity search.
 
         This method first retrieves documents based on similarity to the query, and
         then applies a traversal strategy to explore connected nodes in the graph.
 
-        Args:
-            query (str): The query string to search for.
-            edges (list[str | tuple[str, str]] | None): Optional edge definitions for
-                this retrieval.
-            initial_roots (Sequence[str]): Document IDs to use as initial roots. The top
-                `adjacent_k` nodes connected to each root are included in the initial
-                candidates.
-            filter (dict[str, Any] | None): Optional metadata filter to apply.
-            store_kwargs (dict[str, Any]): Additional keyword arguments for the store.
-            **kwargs (Any): Additional arguments for configuring the traversal strategy.
+        Parameters
+        ----------
+        query : str
+            The query string to search for.
+        edges : list[str | tuple[str, str]], optional
+            Optional edge definitions for this retrieval.
+        initial_roots : Sequence[str]
+            Document IDs to use as initial roots. The top `adjacent_k` nodes
+            connected to each root are included in the initial candidates.
+        filter : dict[str, Any], optional
+            Optional metadata filter to apply.
+        store_kwargs : dict[str, Any], optional
+            Additional keyword arguments for the store.
+        **kwargs : Any
+            Additional arguments for configuring the traversal strategy.
 
         Returns
         -------
-            list[Document]: The retrieved documents.
+        list[Document]
+            The retrieved documents.
         """
         traversal = Traversal(
             query=query,
@@ -159,20 +173,26 @@ class GraphRetriever(BaseRetriever):
         This method first retrieves documents based on similarity to the query, and
         then applies a traversal strategy to explore connected nodes in the graph.
 
-        Args:
-            query (str): The query string to search for.
-            edges (list[str | tuple[str, str]] | None): Optional edge definitions for
-                this retrieval.
-            initial_roots (Sequence[str]): Document IDs to use as initial roots. The top
-                `adjacent_k` nodes connected to each root are included in the initial
-                candidates.
-            filter (dict[str, Any] | None): Optional metadata filter to apply.
-            store_kwargs (dict[str, Any]): Additional keyword arguments for the store.
-            **kwargs (Any): Additional arguments for configuring the traversal strategy.
+        Parameters
+        ----------
+        query : str
+            The query string to search for.
+        edges : list[str | tuple[str, str]], optional
+            Override edge definitions for this invocation.
+        initial_roots : Sequence[str]
+            Document IDs to use as initial roots. The top `adjacent_k` nodes
+            connected to each root are included in the initial candidates.
+        filter : dict[str, Any], optional
+            Optional metadata filter to apply.
+        store_kwargs : dict[str, Any], optional
+            Additional keyword arguments for the store.
+        **kwargs : Any
+            Additional arguments for configuring the traversal strategy.
 
         Returns
         -------
-            list[Document]: The retrieved documents.
+        list[Document]
+            The retrieved documents.
         """
         traversal = Traversal(
             query=query,

--- a/packages/langchain-graph-retriever/src/langchain_graph_retriever/node.py
+++ b/packages/langchain-graph-retriever/src/langchain_graph_retriever/node.py
@@ -8,26 +8,32 @@ from .edge_helper import Edge
 
 @dataclass
 class Node:
-    """Represents a node in the traversal graph.
+    """
+    Represents a node in the traversal graph.
 
     The `Node` class contains information about a document during graph traversal,
     including its depth, embedding, edges, and metadata.
 
     Attributes
     ----------
-        id (str): The unique identifier of the document represented by this node.
-        depth (int): The depth (number of edges) through which this node was discovered.
-            This depth may not reflect the true depth in the full graph if only a subset
-            of edges is retrieved.
-        embedding (list[float]): The embedding vector of the document, used for
-            similarity calculations.
-        incoming_edges (set[Edge]): The set of edges pointing to this node.
-        outgoing_edges (set[Edge]): The set of edges originating from this node.
-        metadata (dict[str, Any]): Metadata from the original document. This is a
-            reference to the original document metadata and should not be modified
-            directly.
-        extra_metadata (dict[str, Any]): Additional metadata to override or augment
-            the original document metadata during traversal.
+    id : str
+        The unique identifier of the document represented by this node.
+    depth : int
+        The depth (number of edges) through which this node was discovered. This
+        depth may not reflect the true depth in the full graph if only a subset
+        of edges is retrieved.
+    embedding : list[float])
+        The embedding vector of the document, used for similarity calculations.
+    incoming_edges : set[Edge]
+        The set of edges pointing to this node.
+    outgoing_edges : set[Edge]
+        The set of edges originating from this node.
+    metadata : dict[str, Any]
+        Metadata from the original document. This is a reference to the original
+        document metadata and should not be modified directly.
+    extra_metadata : dict[str, Any]
+        Additional metadata to override or augment the original document
+        metadata during traversal.
     """
 
     id: str

--- a/packages/langchain-graph-retriever/src/langchain_graph_retriever/strategies/base.py
+++ b/packages/langchain-graph-retriever/src/langchain_graph_retriever/strategies/base.py
@@ -20,76 +20,88 @@ class Strategy(BaseModel, abc.ABC):
     a graph traversal. Implementations can customize behaviors like limiting the depth
     of traversal, scoring nodes, or selecting the next set of nodes for exploration.
 
+    Parameters
+    ----------
+    k : int, default 5
+        Maximum number of nodes to retrieve during traversal.
+    start_k : int, default 4
+        Number of documents to fetch via similarity for starting the traversal.
+        Added to any initial roots provided to the traversal.
+    adjacent_k : int, default 10
+        Number of documents to fetch for each outgoing edge.
+    max_depth : int, optional
+        Maximum traversal depth. If `None`, there is no limit.
+
     Attributes
     ----------
-        k (int): Number of nodes to retrieve during traversal. Default is 5.
-        start_k (int): Number of initial documents to fetch via similarity, added
-            to any specified starting nodes. Default is 4.
-        adjacent_k (int): Number of adjacent documents to fetch for each outgoing edge.
-            Default is 10.
-        max_depth (int | None): Maximum traversal depth. If None, there is no limit.
-        query_embedding (list[float]): Embedding vector for the query.
+    k : int
+        Maximum number of nodes to retrieve during traversal.
+    start_k : int
+        Number of documents to fetch via similarity for starting the traversal.
+        Added to any initial roots provided to the traversal.
+    adjacent_k : int
+        Number of documents to fetch for each outgoing edge.
+    max_depth : int
+        Maximum traversal depth. If `None`, there is no limit.
     """
 
     k: int = 5
-    """Number of nodes to retrieve during the traversal. Default 5."""
-
     start_k: int = 4
-    """Number of initial documents to fetch via similarity.
-
-    Will be added to the specified starting nodes, if any.
-    """
-
     adjacent_k: int = 10
-    """Number of adjacent Documents to fetch for each outgoing edge. Default 10.
-    """
-
     max_depth: int | None = None
-    """Maximum depth to retrieve. Default no limit."""
 
-    query_embedding: list[float] = []
-    """Query embedding."""
+    _query_embedding: list[float] = []
 
     @abc.abstractmethod
     def discover_nodes(self, nodes: dict[str, Node]) -> None:
-        """Add discovered nodes to the strategy.
+        """
+        Add discovered nodes to the strategy.
 
         This method updates the strategy's state with nodes discovered during
         the traversal process.
 
-        Args:
-            nodes (dict[str, Node]): Discovered nodes keyed by their IDs.
+        Parameters
+        ----------
+        nodes : dict[str, Node]
+            Discovered nodes keyed by their IDs.
         """
         ...
 
     @abc.abstractmethod
     def select_nodes(self, *, limit: int) -> Iterable[Node]:
-        """Select discovered nodes to visit in the next iteration.
+        """
+        Select discovered nodes to visit in the next iteration.
 
         This method determines which nodes will be traversed next. If it returns
         an empty list, traversal ends even if fewer than `k` nodes have been selected.
 
-        Args:
-            limit (int): Maximum number of nodes to select.
+        Parameters
+        ----------
+        limit :
+            Maximum number of nodes to select.
 
         Returns
         -------
-            Iterable[Node]: Selected nodes for the next iteration. Traversal
-            ends if this is empty.
+        Iterable[Node]
+            Selected nodes for the next iteration. Traversal ends if this is empty.
         """
         ...
 
     def finalize_nodes(self, nodes: Iterable[Node]) -> Iterable[Node]:
-        """Finalize the selected nodes.
+        """
+        Finalize the selected nodes.
 
         This method is called before returning the final set of nodes.
 
-        Args:
-            nodes (Iterable[Node]): Nodes selected for finalization.
+        Parameters
+        ----------
+        nodes : Iterable[Node]
+            Nodes selected for finalization.
 
         Returns
         -------
-            Iterable[Node]: Finalized nodes.
+        Iterable[Node]
+            Finalized nodes.
         """
         return nodes
 
@@ -98,22 +110,28 @@ class Strategy(BaseModel, abc.ABC):
         base_strategy: Strategy,
         **kwargs: Any,
     ) -> Strategy:
-        """Build a strategy for a retrieval operation.
+        """
+        Build a strategy for a retrieval operation.
 
         Combines a base strategy with any provided keyword arguments to
         create a customized traversal strategy.
 
-        Args:
-            base_strategy (Strategy): The base strategy to start with.
-            **kwargs: Additional configuration options for the strategy.
+        Parameters
+        ----------
+        base_strategy : Strategy
+            The base strategy to start with.
+        **kwargs : Any
+            Additional configuration options for the strategy.
 
         Returns
         -------
-            Strategy: A configured strategy instance.
+        Strategy
+            A configured strategy instance.
 
         Raises
         ------
-            ValueError: If 'strategy' is set incorrectly or extra arguments are invalid.
+        ValueError
+            If 'strategy' is set incorrectly or extra arguments are invalid.
         """
         # Check if there is a new strategy to use. Otherwise, use the base.
         strategy: Strategy
@@ -150,16 +168,20 @@ class Strategy(BaseModel, abc.ABC):
 
 
 def _invalid_keys(model: BaseModel, dict: dict[str, Any]) -> str | None:
-    """Identify invalid keys in the given dictionary for a Pydantic model.
+    """
+    Identify invalid keys in the given dictionary for a Pydantic model.
 
-    Args:
-        model (BaseModel): The Pydantic model to validate against.
-        dict (dict[str, Any]): The dictionary to check.
+    Parameters
+    ----------
+    model : BaseModel
+        The Pydantic model to validate against.
+    dict : dict[str, Any]
+        The dictionary to check.
 
     Returns
     -------
-        str | None: A comma-separated string of invalid keys, or None if all keys
-        are valid.
+    str | None
+        A comma-separated string of invalid keys, if any.
     """
     invalid_keys = set(dict.keys()) - set(model.model_fields.keys())
     if invalid_keys:

--- a/packages/langchain-graph-retriever/src/langchain_graph_retriever/strategies/eager.py
+++ b/packages/langchain-graph-retriever/src/langchain_graph_retriever/strategies/eager.py
@@ -16,15 +16,29 @@ class Eager(Strategy):
     scenarios where all nodes at the current depth should be explored before proceeding
     to the next depth.
 
+    Parameters
+    ----------
+    k : int, default 5
+        Maximum number of nodes to retrieve during traversal.
+    start_k : int, default 4
+        Number of documents to fetch via similarity for starting the traversal.
+        Added to any initial roots provided to the traversal.
+    adjacent_k : int, default 10
+        Number of documents to fetch for each outgoing edge.
+    max_depth : int, optional
+        Maximum traversal depth. If `None`, there is no limit.
+
     Attributes
     ----------
-        k (int): Number of nodes to retrieve during traversal. Default is 5.
-        start_k (int): Number of initial documents to fetch via similarity, added
-            to any specified starting nodes. Default is 4.
-        adjacent_k (int): Number of adjacent documents to fetch for each outgoing edge.
-            Default is 10.
-        max_depth (int | None): Maximum traversal depth. If None, there is no limit.
-        query_embedding (list[float]): Embedding vector for the query.
+    k : int
+        Maximum number of nodes to retrieve during traversal.
+    start_k : int
+        Number of documents to fetch via similarity for starting the traversal.
+        Added to any initial roots provided to the traversal.
+    adjacent_k : int
+        Number of documents to fetch for each outgoing edge.
+    max_depth : int
+        Maximum traversal depth. If `None`, there is no limit.
     """
 
     _nodes: list[Node] = []

--- a/packages/langchain-graph-retriever/src/langchain_graph_retriever/strategies/scored.py
+++ b/packages/langchain-graph-retriever/src/langchain_graph_retriever/strategies/scored.py
@@ -9,26 +9,48 @@ from .base import Strategy
 
 
 class Scored(Strategy):
-    """Score-based traversal strategy.
+    """
+    Score-based traversal strategy.
 
     This strategy uses a scoring function (`scorer`) to rank nodes and selects
     the top-scored nodes in each iteration. Nodes are processed based on their
     scores, ensuring that higher-priority nodes are visited earlier.
 
+    Parameters
+    ----------
+    k : int, default 5
+        Maximum number of nodes to retrieve during traversal.
+    start_k : int, default 4
+        Number of documents to fetch via similarity for starting the traversal.
+        Added to any initial roots provided to the traversal.
+    adjacent_k : int, default 10
+        Number of documents to fetch for each outgoing edge.
+    max_depth : int, default None
+        Maximum traversal depth. If `None`, there is no limit.
+    scorer : Callable[[Node], float]
+        A function to compute the score for each node. This is invoked once when
+        the node is first discovered. Note that the depth of the node may be an
+        upper-bound on the actual shortest path.
+    select_k : int, default 10
+        The number of top-scored nodes to select in each iteration.
+
     Attributes
     ----------
-        k (int): Number of nodes to retrieve during traversal. Default is 5.
-        start_k (int): Number of initial documents to fetch via similarity, added
-            to any specified starting nodes. Default is 4.
-        adjacent_k (int): Number of adjacent documents to fetch for each outgoing edge.
-            Default is 10.
-        max_depth (int | None): Maximum traversal depth. If None, there is no limit.
-        query_embedding (list[float]): Embedding vector for the query.
-        scorer (Callable[[Node], float]): A function to compute the score for each node.
-            This is invoked once when the node is first discovered. Note that the depth
-            of the node may be an upper-bound on the actual shortest path.
-        select_k (int): The number of top-scored nodes to select in each iteration.
-            Default is 10.
+    k : int
+        Maximum number of nodes to retrieve during traversal.
+    start_k : int
+        Number of documents to fetch via similarity for starting the traversal.
+        Added to any initial roots provided to the traversal.
+    adjacent_k : int
+        Number of documents to fetch for each outgoing edge.
+    max_depth : int
+        Maximum traversal depth. If `None`, there is no limit.
+    scorer : Callable[[Node], float]
+        A function to compute the score for each node. This is invoked once when
+        the node is first discovered. Note that the depth of the node may be an
+        upper-bound on the actual shortest path.
+    select_k : int
+        The number of top-scored nodes to select in each iteration.
     """
 
     scorer: Callable[[Node], float]

--- a/packages/langchain-graph-retriever/src/langchain_graph_retriever/utils/math.py
+++ b/packages/langchain-graph-retriever/src/langchain_graph_retriever/utils/math.py
@@ -10,29 +10,35 @@ Matrix = list[list[float]] | list[np.ndarray] | np.ndarray
 
 
 def cosine_similarity(X: Matrix, Y: Matrix) -> np.ndarray:
-    """Compute row-wise cosine similarity between two equal-width matrices.
+    """
+    Compute row-wise cosine similarity between two equal-width matrices.
 
-    Args:
-        X (Matrix): A matrix of shape (m, n), where `m` is the number of rows and
-            `n` is the number of columns (features).
-        Y (Matrix): A matrix of shape (p, n), where `p` is the number of rows and
-            `n` is the number of columns (features).
+    Parameters
+    ----------
+    X : Matrix
+        A matrix of shape (m, n), where `m` is the number of rows and `n` is the
+        number of columns (features).
+    Y : Matrix
+        A matrix of shape (p, n), where `p` is the number of rows and `n` is the
+        number of columns (features).
 
     Returns
     -------
-        np.ndarray: A matrix of shape (m, p) containing the cosine similarity scores
+    np.ndarray
+        A matrix of shape (m, p) containing the cosine similarity scores
         between each row of `X` and each row of `Y`.
 
     Raises
     ------
-        ValueError: If the number of columns in `X` and `Y` are not equal.
+    ValueError
+        If the number of columns in `X` and `Y` are not equal.
 
     Notes
     -----
-        - If the `simsimd` library is available, it will be used for performance
-          optimization. Otherwise, the function falls back to a NumPy implementation.
-        - Divide-by-zero and invalid values in similarity calculations are replaced
-          with 0.0 in the output.
+    - If the `simsimd` library is available, it will be used for performance
+      optimization. Otherwise, the function falls back to a NumPy implementation.
+    - Divide-by-zero and invalid values in similarity calculations are replaced
+      with 0.0 in the output.
     """
     if len(X) == 0 or len(Y) == 0:
         return np.array([])
@@ -71,34 +77,40 @@ def cosine_similarity_top_k(
     top_k: int | None = 5,
     score_threshold: float | None = None,
 ) -> tuple[list[tuple[int, int]], list[float]]:
-    """Compute cosine similarity with filtering for top-k results and a score threshold.
+    """
+    Compute cosine similarity with filtering for top-k results and a score threshold.
 
     This function calculates the row-wise cosine similarity between two matrices and
     returns the indices and scores of the top results based on the provided
     parameters.
 
-    Args:
-        X (Matrix): A matrix of shape (m, n), where `m` is the number of rows and
-            `n` is the number of columns (features).
-        Y (Matrix): A matrix of shape (p, n), where `p` is the number of rows and
-            `n` is the number of columns (features).
-        top_k (int | None, optional): The maximum number of results to return.
-            Defaults to 5. If None, returns all results above the score threshold.
-        score_threshold (float | None, optional): Minimum cosine similarity score
-            for results to be included. Defaults to -1.0.
+    Parameters
+    ----------
+    X : Matrix
+        A matrix of shape (m, n), where `m` is the number of rows and `n` is the
+        number of columns (features).
+    Y : Matrix
+        A matrix of shape (p, n), where `p` is the number of rows and `n` is the
+        number of columns (features).
+    top_k : int, default 5
+        The maximum number of results to return. If `None`, returns all results
+        above the score threshold.
+    score_threshold: float, default -1.0
+        Minimum cosine similarity score for results to be included.
 
     Returns
     -------
-        tuple[list[tuple[int, int]], list[float]]:
-            - A list of index pairs (X_idx, Y_idx) corresponding to the highest
-              similarity scores.
-            - A list of the corresponding similarity scores.
+    indices : list[tuple[int, int]]
+        A list of index pairs (X_idx, Y_idx) corresponding to the highest
+        similarity scores.
+    scores : list[float]
+        A list of the corresponding similarity scores.
 
     Notes
     -----
-        - If `top_k` is None or greater than the number of valid scores, all scores
-          above the threshold will be returned.
-        - The results are sorted in descending order of similarity scores.
+    - If `top_k` is None or greater than the number of valid scores, all scores
+      above the threshold will be returned.
+    - The results are sorted in descending order of similarity scores.
     """
     if len(X) == 0 or len(Y) == 0:
         return [], []

--- a/packages/langchain-graph-retriever/tests/embeddings/simple_embeddings.py
+++ b/packages/langchain-graph-retriever/tests/embeddings/simple_embeddings.py
@@ -23,9 +23,19 @@ class Angular2DEmbeddings(BaseEmbeddings):
     def embed_query(self, text: str) -> list[float]:
         """
         Convert input text to a 'vector' (list of floats).
-        If the text is a number, use it as the angle for the
-        unit vector in units of pi.
-        Any other input text becomes the singular result [0, 0] !
+
+        Parameters
+        ----------
+        text: str
+            The text to embed.
+
+        Returns
+        -------
+        list[float]
+            If the text is a number, use it as the angle for the unit vector in
+            units of pi.
+
+            Any other input text becomes the singular result `[0, 0]`.
         """
         try:
             angle = float(text)

--- a/packages/langchain-graph-retriever/tests/unit_tests/test_graph_retriever.py
+++ b/packages/langchain-graph-retriever/tests/unit_tests/test_graph_retriever.py
@@ -7,7 +7,8 @@ from langchain_graph_retriever.strategies import Mmr
 
 def test_mmr_parameters() -> None:
     # Makes sure that copying the MMR strategy creates new embeddings.
-    mmr1 = Mmr(query_embedding=[0.25, 0.5, 0.75])
+    mmr1 = Mmr()
+    mmr1._query_embedding = [0.25, 0.5, 0.75]
     assert id(mmr1._nd_query_embedding) == id(mmr1._nd_query_embedding)
 
     mmr2 = mmr1.model_copy(deep=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ pythonpath = ["."]
 testpaths = ["tests"]
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "T201", "D", "W", "UP"]
+preview = true
+select = ["E", "F", "I", "T201", "D", "W", "UP", "DOC", "D213"]
 ignore = ["D100", "D104", "D107"]
 
 [tool.ruff.lint.pydocstyle]


### PR DESCRIPTION
Tried to hit everything, but may have missed them.

Thoughts / observations

1. In subclasses, I added the `@override` annotation, allowing me to remove documentation that would copy the superclass.
2. Lots of this feels very redundant with the type information. Especially copying pydantic things into the Parameters (for `__init__`) and `Attributes` (for the instance). Maybe a way to reduce.
3. I noticed no linking from types to the corresponding instances. Not sure if there is an easy way to get that.
4. I noticed warnings about parameters of a base model not being defined on the subclasses. Not sure if we can suppress or do anything about these.