### PR TITLE
Allow id edges

### DIFF
--- a/packages/langchain-graph-retriever/src/langchain_graph_retriever/adapters/base.py
+++ b/packages/langchain-graph-retriever/src/langchain_graph_retriever/adapters/base.py
@@ -495,6 +495,11 @@ class Adapter(Generic[StoreT], abc.ABC):
         -------
         Iterable[Document]
             Iterable of adjacent nodes.
+
+        Raises
+        ------
+        ValueError
+            If unsupported edge types are encountered.
         """
         results: list[Document] = []
 
@@ -547,19 +552,26 @@ class Adapter(Generic[StoreT], abc.ABC):
         -------
         Iterable[Document]
             Iterable of adjacent nodes.
+
+        Raises
+        ------
+        ValueError
+            If unsupported edge types are encountered.
         """
         tasks = []
         ids = []
         for outgoing_edge in outgoing_edges:
             if isinstance(outgoing_edge, MetadataEdge):
-                tasks.append(self.asimilarity_search_with_embedding_by_vector(
-                    embedding=query_embedding,
-                    k=adjacent_k,
-                    filter=self._get_metadata_filter(
-                        base_filter=filter, edge=outgoing_edge
-                    ),
-                    **kwargs,
-                ))
+                tasks.append(
+                    self.asimilarity_search_with_embedding_by_vector(
+                        embedding=query_embedding,
+                        k=adjacent_k,
+                        filter=self._get_metadata_filter(
+                            base_filter=filter, edge=outgoing_edge
+                        ),
+                        **kwargs,
+                    )
+                )
             elif isinstance(outgoing_edge, IdEdge):
                 ids.append(outgoing_edge.id)
             else:

--- a/packages/langchain-graph-retriever/src/langchain_graph_retriever/graph_retriever.py
+++ b/packages/langchain-graph-retriever/src/langchain_graph_retriever/graph_retriever.py
@@ -15,7 +15,7 @@ from pydantic import ConfigDict, computed_field, model_validator
 from langchain_graph_retriever._traversal import Traversal
 from langchain_graph_retriever.adapters.base import Adapter
 from langchain_graph_retriever.adapters.inference import infer_adapter
-from langchain_graph_retriever.edges.metadata import MetadataEdgeFunction
+from langchain_graph_retriever.edges.metadata import Id, MetadataEdgeFunction
 from langchain_graph_retriever.strategies import Eager, Strategy
 from langchain_graph_retriever.types import EdgeFunction
 
@@ -45,14 +45,14 @@ class GraphRetriever(BaseRetriever):
     ----------
     store : Adapter | VectorStore
         The vector store or adapter used for document retrieval.
-    edges : list[str | tuple[str, str]]
+    edges : list[str | tuple[str, str | Id]]
         Definitions of edges used for graph traversal.
     strategy : Strategy
         The traversal strategy to use.
     """
 
     store: Adapter | VectorStore
-    edges: list[str | tuple[str, str]]
+    edges: list[str | tuple[str, str | Id]]
     strategy: Strategy = Eager()
 
     # Capture the extra fields in `self.model_extra` rather than ignoring.
@@ -81,7 +81,7 @@ class GraphRetriever(BaseRetriever):
         return self
 
     def _edge_function(
-        self, edges: list[str | tuple[str, str]] | None = None
+        self, edges: list[str | tuple[str, str | Id]] | None = None
     ) -> EdgeFunction:
         """
         Create an `EdgeHelper` instance for managing edges during traversal.
@@ -110,7 +110,7 @@ class GraphRetriever(BaseRetriever):
         self,
         query: str,
         *,
-        edges: list[str | tuple[str, str]] | None = None,
+        edges: list[str | tuple[str, str | Id]] | None = None,
         initial_roots: Sequence[str] = (),
         filter: dict[str, Any] | None = None,
         store_kwargs: dict[str, Any] = {},
@@ -159,7 +159,7 @@ class GraphRetriever(BaseRetriever):
         self,
         query: str,
         *,
-        edges: list[str | tuple[str, str]] | None = None,
+        edges: list[str | tuple[str, str | Id]] | None = None,
         initial_roots: Sequence[str] = (),
         filter: dict[str, Any] | None = None,
         store_kwargs: dict[str, Any] = {},

--- a/packages/langchain-graph-retriever/tests/integration_tests/adapters/test_adapters.py
+++ b/packages/langchain-graph-retriever/tests/integration_tests/adapters/test_adapters.py
@@ -182,8 +182,8 @@ GET_ADJACENT_CASES: dict[str, GetAdjacentCase] = {
             "cat",
             "dog",
             "crab",
-        ]
-    )
+        ],
+    ),
 }
 
 

--- a/packages/langchain-graph-retriever/tests/integration_tests/test_traversal_eager.py
+++ b/packages/langchain-graph-retriever/tests/integration_tests/test_traversal_eager.py
@@ -1,9 +1,11 @@
-from langchain_graph_retriever.adapters.in_memory import InMemoryAdapter
 import pytest
 from langchain_core.documents import Document
+from langchain_core.vectorstores import InMemoryVectorStore
 from langchain_graph_retriever import (
     GraphRetriever,
 )
+from langchain_graph_retriever.adapters.in_memory import InMemoryAdapter
+from langchain_graph_retriever.edges.metadata import Id
 from langchain_graph_retriever.strategies import (
     Eager,
 )
@@ -12,8 +14,11 @@ from tests.animal_docs import (
     ANIMALS_DEPTH_0_EXPECTED,
     ANIMALS_QUERY,
 )
-from langchain_core.vectorstores import InMemoryVectorStore
-from tests.embeddings.simple_embeddings import Angular2DEmbeddings, EarthEmbeddings, ParserEmbeddings
+from tests.embeddings.simple_embeddings import (
+    Angular2DEmbeddings,
+    EarthEmbeddings,
+    ParserEmbeddings,
+)
 from tests.integration_tests.assertions import assert_document_format, sorted_doc_ids
 from tests.integration_tests.stores import Adapter, AdapterFactory
 
@@ -315,6 +320,7 @@ async def test_earth(
     )
     assert sorted_doc_ids(docs) == ["doc1", "doc2", "greetings"]
 
+
 async def test_ids(invoker) -> None:
     v0 = Document(id="v0", page_content="-0.124")
     v1 = Document(id="v1", page_content="+0.127", metadata={"mentions": ["v0"]})
@@ -326,14 +332,14 @@ async def test_ids(invoker) -> None:
 
     retriever = GraphRetriever(
         store=InMemoryAdapter(vector_store=store),
-        edges=[("mentions", "$id")],
+        edges=[("mentions", Id())],
     )
 
     docs: list[Document] = await invoker(retriever, "+0.249", start_k=1, max_depth=0)
     assert sorted_doc_ids(docs) == ["v2"]
 
-    docs: list[Document] = await invoker(retriever, "+0.249", start_k=1, max_depth=1)
+    docs = await invoker(retriever, "+0.249", start_k=1, max_depth=1)
     assert sorted_doc_ids(docs) == ["v1", "v2", "v3"]
 
-    docs: list[Document] = await invoker(retriever, "+0.249", start_k=1, max_depth=3)
+    docs = await invoker(retriever, "+0.249", start_k=1, max_depth=3)
     assert sorted_doc_ids(docs) == ["v0", "v1", "v2", "v3"]

--- a/packages/langchain-graph-retriever/tests/unit_tests/edges/test_metadata.py
+++ b/packages/langchain-graph-retriever/tests/unit_tests/edges/test_metadata.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 import pytest
-from langchain_graph_retriever.edges.metadata import MetadataEdgeFunction
+from langchain_graph_retriever.edges.metadata import Id, MetadataEdgeFunction
 from langchain_graph_retriever.types import Edges, IdEdge, MetadataEdge, Node
 
 
@@ -36,8 +36,9 @@ def test_edge_function():
         {MetadataEdge("url", "a"), MetadataEdge("url", "c")},
     )
 
+
 def test_link_to_id():
-    edge_function = MetadataEdgeFunction([("mentions", "$id")])
+    edge_function = MetadataEdgeFunction([("mentions", Id())])
     assert edge_function(mk_node({"mentions": ["a", "c"]})) == Edges(
         {IdEdge("id")},
         {IdEdge("a"), IdEdge("c")},


### PR DESCRIPTION
Adds support for `$id` in edge targets (eg., `("mentions", "$id")` to link from mentions to the ID.

This allows us to avoid copying the ID into the metadata (simplifying some example code I'm writing), and also demonstrating some of the new "generic edge direction". In this case, the same strategy just handles the `$id` target specially, spitting out `IdEdge(...)`.