### PR TITLE
limit get_adjacent to k items regardless of edges

### DIFF
--- a/packages/graph-retriever/src/graph_retriever/adapters/base.py
+++ b/packages/graph-retriever/src/graph_retriever/adapters/base.py
@@ -7,8 +7,8 @@ from typing import Any
 
 from graph_retriever.content import Content
 from graph_retriever.types import Edge, IdEdge, MetadataEdge
-from graph_retriever.utils.top_k import top_k
 from graph_retriever.utils.run_in_executor import run_in_executor
+from graph_retriever.utils.top_k import top_k
 
 
 class Adapter(abc.ABC):

--- a/packages/graph-retriever/src/graph_retriever/content.py
+++ b/packages/graph-retriever/src/graph_retriever/content.py
@@ -18,6 +18,9 @@ class Content(BaseModel):
         The content.
     embedding : list[float]
         The embedding of the content.
+    score : float | None
+        The similarity of the embedding to the query.
+        This is optional, and may not be set depending on the content.
     metadata : dict[str, Any]
         The metadata associated with the content.
     mime_type : str
@@ -30,12 +33,14 @@ class Content(BaseModel):
     metadata: dict[str, Any] = {}
 
     mime_type: str = "text/plain"
+    score: float | None = None
 
     @staticmethod
     def new(
         id: str,
         content: str,
         embedding: list[float] | Callable[[str], list[float]],
+        score: float | None = None,
         metadata: dict[str, Any] = {},
         mime_type: str = "text/plain",
     ) -> Content:
@@ -51,6 +56,8 @@ class Content(BaseModel):
         embedding : list[float] | Callable[[str], list[float]]
             The embedding, or a function to apply to the content to compute the
             embedding.
+        score : float | None, optional
+            The similarity of the embedding to the query.
         metadata : dict[str, Any], optional
             The metadata associated with the content.
         mime_type : str, optional
@@ -65,6 +72,7 @@ class Content(BaseModel):
             id=id,
             content=content,
             embedding=embedding(content) if callable(embedding) else embedding,
+            score=score,
             metadata=metadata,
             mime_type=mime_type,
         )

--- a/packages/graph-retriever/src/graph_retriever/testing/adapter_tests.py
+++ b/packages/graph-retriever/src/graph_retriever/testing/adapter_tests.py
@@ -30,28 +30,14 @@ def assert_valid_results(docs: Iterable[Content]):
 
 
 def assert_ids_any_order(
-    results: Iterable[Content], expected: list[str], min_intersection: int | None = None
+    results: Iterable[Content],
+    expected: list[str],
 ) -> None:
     """Assert the results are valid and match the IDs."""
     assert_valid_results(results)
 
     result_ids = [r.id for r in results]
-
-    if min_intersection is not None:
-        intersection = set(result_ids).intersection(expected)
-        min_intersection = min(min_intersection, len(expected))
-        assert len(intersection) >= min_intersection, (
-            f"{result_ids} should contain at least {min_intersection} "
-            f"from {expected} was {intersection}"
-        )
-
-        unexpected = set(result_ids) - set(expected)
-        assert not unexpected, (
-            f"{result_ids} should contain only elements of {expected}"
-            f", but had {unexpected}"
-        )
-    else:
-        assert set(result_ids) == set(expected), "should contain exactly expected IDs"
+    assert set(result_ids) == set(expected), "should contain exactly expected IDs"
 
 
 @dataclass
@@ -160,7 +146,7 @@ class GetAdjacentCase:
     edges: set[Edge]
     expected: list[str]
 
-    adjacent_k: int = 4
+    k: int = 4
     filter: dict[str, Any] | None = None
 
 
@@ -171,12 +157,6 @@ GET_ADJACENT_CASES: list[GetAdjacentCase] = [
         edges={MetadataEdge("type", "mammal")},
         expected=["horse", "llama", "dog", "cat"],
     ),
-    # Note: Currently, all stores implement get adjacent by performing a
-    # separate search for each edge. This means that it returns up to
-    # `adjacent_k * len(outgoing_edges)` results. This will not be true if some
-    # stores (eg., OpenSearch) implement get adjacent more efficiently. We may
-    # wish to have `get_adjacent` select the top `adjacent_k` by sorting by
-    # similarity internally to better reflect this.
     GetAdjacentCase(
         "two_edges_same_field",
         "domesticated hunters",
@@ -186,11 +166,9 @@ GET_ADJACENT_CASES: list[GetAdjacentCase] = [
         },
         expected=[
             "cat",
-            "crab",
             "dog",
             "horse",
             "llama",
-            "lobster",
         ],
     ),
     GetAdjacentCase(
@@ -219,6 +197,21 @@ GET_ADJACENT_CASES: list[GetAdjacentCase] = [
         ],
     ),
     GetAdjacentCase(
+        "ids_limit_k",
+        "domesticated hunters",
+        edges={
+            IdEdge("cat"),
+            IdEdge("dog"),
+            IdEdge("unicorn"),
+            IdEdge("goat"),
+        },
+        k=2,
+        expected=[
+            "cat",
+            "dog",
+        ],
+    ),
+    GetAdjacentCase(
         "filtered_ids",
         "domesticated hunters",
         edges={
@@ -232,7 +225,23 @@ GET_ADJACENT_CASES: list[GetAdjacentCase] = [
             "chinchilla",
         ],
     ),
-    # Add test for ID edges and metadata edges combined.
+    GetAdjacentCase(
+        "metadata_and_id",
+        "domesticated hunters",
+        edges={
+            IdEdge("cat"),
+            MetadataEdge("type", "reptile"),
+        },
+        k=6,
+        expected=[
+            "alligator",  # reptile
+            "crocodile",  # reptile
+            "cat",  # by ID
+            "chameleon",  # reptile
+            "gecko",  # reptile
+            "komodo dragon",  # reptile
+        ],
+    ),
 ]
 
 
@@ -345,14 +354,10 @@ class AdapterComplianceSuite(abc.ABC):
         results = adapter.get_adjacent(
             edges=get_adjacent_case.edges,
             query_embedding=embedding,
-            k=get_adjacent_case.adjacent_k,
+            k=get_adjacent_case.k,
             filter=get_adjacent_case.filter,
         )
-        assert_ids_any_order(
-            results,
-            get_adjacent_case.expected,
-            min_intersection=get_adjacent_case.adjacent_k,
-        )
+        assert_ids_any_order(results, get_adjacent_case.expected)
 
     async def test_aget_adjacent(
         self, adapter: Adapter, get_adjacent_case: GetAdjacentCase
@@ -363,11 +368,7 @@ class AdapterComplianceSuite(abc.ABC):
         results = await adapter.aget_adjacent(
             edges=get_adjacent_case.edges,
             query_embedding=embedding,
-            k=get_adjacent_case.adjacent_k,
+            k=get_adjacent_case.k,
             filter=get_adjacent_case.filter,
         )
-        assert_ids_any_order(
-            results,
-            get_adjacent_case.expected,
-            min_intersection=get_adjacent_case.adjacent_k,
-        )
+        assert_ids_any_order(results, get_adjacent_case.expected)

--- a/packages/graph-retriever/src/graph_retriever/testing/adapter_tests.py
+++ b/packages/graph-retriever/src/graph_retriever/testing/adapter_tests.py
@@ -203,7 +203,7 @@ GET_ADJACENT_CASES: list[GetAdjacentCase] = [
             IdEdge("cat"),
             IdEdge("dog"),
             IdEdge("unicorn"),
-            IdEdge("goat"),
+            IdEdge("antelope"),
         },
         k=2,
         expected=[
@@ -218,7 +218,7 @@ GET_ADJACENT_CASES: list[GetAdjacentCase] = [
             IdEdge("boar"),
             IdEdge("chinchilla"),
             IdEdge("unicorn"),
-            IdEdge("cobra"),
+            IdEdge("griaffe"),
         },
         filter={"keywords": "andes"},
         expected=[

--- a/packages/graph-retriever/src/graph_retriever/utils/top_k.py
+++ b/packages/graph-retriever/src/graph_retriever/utils/top_k.py
@@ -1,0 +1,88 @@
+import heapq
+from collections.abc import Iterable
+from typing import cast
+
+from graph_retriever.content import Content
+from graph_retriever.utils.math import cosine_similarity_top_k
+
+
+def top_k(
+    batches: Iterable[list[Content]],
+    *,
+    embedding: list[float],
+    k: int,
+    are_batches_sorted: bool = False,
+) -> list[Content]:
+    """
+    Select the top-k contents from the given batches.
+
+    If all contents have scores, they will be used for the comparison rather
+    than being computed.
+
+    Parameters
+    ----------
+    batches : Iterable[list[Content]]
+        The batches of content to select the top-K from.
+    embedding: list[float]
+        The embedding we're looking for.
+    k : int
+        The number of items to select.
+    are_batches_sorted : bool, default False
+        Whether the content of each batch are sorted. If true, and all content
+        has scores, a more efficient top-K selection will be used which doesn't
+        need to consider all of each batch.
+
+    Returns
+    -------
+    list[Content]
+        Top-K by similarity. All results will have their `score` set.
+    """
+    # TODO: Consider passing threshold here to limit results.
+
+    if all(c.score is not None for batch in batches for c in batch):
+        sorted_items: Iterable[Content]
+        if are_batches_sorted:
+            sorted_items = heapq.merge(*batches, key=_score, reverse=True)
+        else:
+            sorted_items = sorted(
+                [c for batch in batches for c in batch], key=_score, reverse=True
+            )
+
+        # Use a dict as a simple way to de-duplicate by ID.
+        # We may be able to rely on all values with the same score
+        # appearing adjacently (and avoid the dict/set), but we'd
+        # also need to ensure that if two different IDs have the same
+        # score, we don't have `A, B, A`, etc.
+        results: dict[str, Content] = {}
+        for c in sorted_items:
+            results.setdefault(c.id, c)
+            if len(results) >= k:
+                break
+
+        return list(results.values())
+    else:
+        return _similarity_sort_top_k(batches, embedding=embedding, k=k)
+
+
+def _score(content: Content) -> float:
+    return cast(float, content.score)
+
+
+def _similarity_sort_top_k(
+    batches: Iterable[list[Content]], *, embedding: list[float], k: int
+) -> list[Content]:
+    # Flatten the content and use a dict to deduplicate.
+    # We need to do this *before* selecting the top_k to ensure we don't
+    # get duplicates (and fail to produce `k`).
+    flat = list({c.id: c for batch in batches for c in batch}.values())
+
+    top_k, scores = cosine_similarity_top_k(
+        [embedding], [c.embedding for c in flat], top_k=k
+    )
+
+    results = []
+    for (_x, y), score in zip(top_k, scores):
+        content = flat[y]
+        content.score = score
+        results.append(content)
+    return results

--- a/packages/graph-retriever/src/graph_retriever/utils/top_k.py
+++ b/packages/graph-retriever/src/graph_retriever/utils/top_k.py
@@ -7,61 +7,44 @@ from graph_retriever.utils.math import cosine_similarity_top_k
 
 
 def top_k(
-    batches: Iterable[list[Content]],
+    contents: Iterable[Content],
     *,
     embedding: list[float],
     k: int,
-    are_batches_sorted: bool = False,
 ) -> list[Content]:
     """
-    Select the top-k contents from the given batches.
-
-    If all contents have scores, they will be used for the comparison rather
-    than being computed.
+    Select the top-k contents from the given contet.
 
     Parameters
     ----------
-    batches : Iterable[list[Content]]
-        The batches of content to select the top-K from.
+    contents : Iterable[Content]
+        The content from which to select the top-K.
     embedding: list[float]
         The embedding we're looking for.
     k : int
         The number of items to select.
-    are_batches_sorted : bool, default False
-        Whether the content of each batch are sorted. If true, and all content
-        has scores, a more efficient top-K selection will be used which doesn't
-        need to consider all of each batch.
 
     Returns
     -------
     list[Content]
         Top-K by similarity. All results will have their `score` set.
     """
+    # TODO: Consider handling specially cases of already-sorted batches (merge).
     # TODO: Consider passing threshold here to limit results.
 
-    if all(c.score is not None for batch in batches for c in batch):
-        sorted_items: Iterable[Content]
-        if are_batches_sorted:
-            sorted_items = heapq.merge(*batches, key=_score, reverse=True)
-        else:
-            sorted_items = sorted(
-                [c for batch in batches for c in batch], key=_score, reverse=True
-            )
+    # Use dicts to de-duplicate by ID. This ensures we choose the top K distinct
+    # content (rather than K copies of the same content).
+    scored = {c.id: c for c in contents if c.score is not None}
+    unscored = {c.id: c for c in contents if c.score is None if c.id not in scored}
 
-        # Use a dict as a simple way to de-duplicate by ID.
-        # We may be able to rely on all values with the same score
-        # appearing adjacently (and avoid the dict/set), but we'd
-        # also need to ensure that if two different IDs have the same
-        # score, we don't have `A, B, A`, etc.
-        results: dict[str, Content] = {}
-        for c in sorted_items:
-            results.setdefault(c.id, c)
-            if len(results) >= k:
-                break
+    if unscored:
+        top_unscored = _similarity_sort_top_k(list(unscored.values()), embedding=embedding, k=k)
+        scored.update(top_unscored)
 
-        return list(results.values())
-    else:
-        return _similarity_sort_top_k(batches, embedding=embedding, k=k)
+    sorted = list(scored.values())
+    sorted.sort(key=_score, reverse=True)
+
+    return sorted[:k]
 
 
 def _score(content: Content) -> float:
@@ -69,20 +52,18 @@ def _score(content: Content) -> float:
 
 
 def _similarity_sort_top_k(
-    batches: Iterable[list[Content]], *, embedding: list[float], k: int
-) -> list[Content]:
+    contents: list[Content], *, embedding: list[float], k: int
+) -> dict[str, Content]:
     # Flatten the content and use a dict to deduplicate.
     # We need to do this *before* selecting the top_k to ensure we don't
     # get duplicates (and fail to produce `k`).
-    flat = list({c.id: c for batch in batches for c in batch}.values())
-
     top_k, scores = cosine_similarity_top_k(
-        [embedding], [c.embedding for c in flat], top_k=k
+        [embedding], [c.embedding for c in contents], top_k=k
     )
 
-    results = []
+    results = {}
     for (_x, y), score in zip(top_k, scores):
-        content = flat[y]
-        content.score = score
-        results.append(content)
+        c = contents[y]
+        c.score = score
+        results[c.id] = c
     return results

--- a/packages/graph-retriever/src/graph_retriever/utils/top_k.py
+++ b/packages/graph-retriever/src/graph_retriever/utils/top_k.py
@@ -1,4 +1,3 @@
-import heapq
 from collections.abc import Iterable
 from typing import cast
 
@@ -38,7 +37,9 @@ def top_k(
     unscored = {c.id: c for c in contents if c.score is None if c.id not in scored}
 
     if unscored:
-        top_unscored = _similarity_sort_top_k(list(unscored.values()), embedding=embedding, k=k)
+        top_unscored = _similarity_sort_top_k(
+            list(unscored.values()), embedding=embedding, k=k
+        )
         scored.update(top_unscored)
 
     sorted = list(scored.values())

--- a/packages/graph-retriever/tests/strategies/test_eager.py
+++ b/packages/graph-retriever/tests/strategies/test_eager.py
@@ -79,11 +79,7 @@ async def test_animals_keywords(animals: Adapter, sync_or_async: SyncOrAsync):
         "alpaca",
         "bison",
         "cat",
-        "chicken",
-        "cockroach",
         "coyote",
-        "crow",
-        "dingo",
         "dog",
         "fox",
         "gazelle",
@@ -92,7 +88,6 @@ async def test_animals_keywords(animals: Adapter, sync_or_async: SyncOrAsync):
         "jackal",
         "llama",
         "mongoose",
-        "ostrich",
     ]
 
 
@@ -181,7 +176,6 @@ async def test_animals_initial_roots(animals: Adapter, sync_or_async: SyncOrAsyn
         "kangaroo",
         "leopard",
         "moose",
-        "ostrich",
     ]
 
 

--- a/packages/langchain-graph-retriever/src/langchain_graph_retriever/adapters/astra.py
+++ b/packages/langchain-graph-retriever/src/langchain_graph_retriever/adapters/astra.py
@@ -376,9 +376,9 @@ class AstraAdapter(Adapter):
         # Ideally, we could request the `$similarity` projection even
         # without vector sort. And it can't be `False`. It needs to be
         # `None` or it will cause an assertion error.
-        include_similarity=None
+        include_similarity = None
         if not (sort or {}).keys().isdisjoint({"$vector", "$vectorize"}):
-            include_similarity=True
+            include_similarity = True
         hits = astra_env.collection.find(
             filter=query,
             projection=self.vector_store.document_codec.full_projection,
@@ -403,9 +403,9 @@ class AstraAdapter(Adapter):
         # Ideally, we could request the `$similarity` projection even
         # without vector sort. And it can't be `False`. It needs to be
         # `None` or it will cause an assertion error.
-        include_similarity=None
+        include_similarity = None
         if not (sort or {}).keys().isdisjoint({"$vector", "$vectorize"}):
-            include_similarity=True
+            include_similarity = True
         hits = astra_env.async_collection.find(
             filter=query,
             projection=self.vector_store.document_codec.full_projection,

--- a/packages/langchain-graph-retriever/tests/adapters/test_astra.py
+++ b/packages/langchain-graph-retriever/tests/adapters/test_astra.py
@@ -1,9 +1,5 @@
 from collections.abc import Iterator
-from time import sleep
 
-from graph_retriever.adapters.base import Adapter
-from graph_retriever.types import IdEdge
-from graph_retriever.utils.math import cosine_similarity
 import pytest
 from graph_retriever.testing.adapter_tests import AdapterComplianceSuite
 from langchain_astradb.utils.vector_store_codecs import _DefaultVSDocumentCodec

--- a/packages/langchain-graph-retriever/tests/adapters/test_astra.py
+++ b/packages/langchain-graph-retriever/tests/adapters/test_astra.py
@@ -1,5 +1,9 @@
 from collections.abc import Iterator
+from time import sleep
 
+from graph_retriever.adapters.base import Adapter
+from graph_retriever.types import IdEdge
+from graph_retriever.utils.math import cosine_similarity
 import pytest
 from graph_retriever.testing.adapter_tests import AdapterComplianceSuite
 from langchain_astradb.utils.vector_store_codecs import _DefaultVSDocumentCodec


### PR DESCRIPTION
This closes https://github.com/datastax/graph-rag/issues/74. `get_adjacent` and `aget_adjacent`
always return up to `k` items.

This requires the implementations to rerank items
returned from multiple queries to produce at most
`k` items.

This also closes https://github.com/datastax/graph-rag/issues/101.