### PR TITLE
use dataclasses in graph_retriever

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -188,6 +188,11 @@ jobs:
       - name: Set up the environment
         uses: ./.github/actions/setup-python-env
 
+      # mkdocstrings uses `ruff` to format generated signatures.
+      # It doesn't find the version installed by `uv`
+      - name: Install ruff
+        uses: astral-sh/ruff-action@v3
+
       - name: Sync Docs Dependencies
         run: uv sync --all-packages --group=docs --all-extras
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,7 +166,7 @@ jobs:
         run: uv sync --all-packages --group=docs --all-extras
 
       - name: Check if documentation can be built
-        run: uv run mkdocs build
+        run: uv run mkdocs build --strict
         id: build
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,0 +1,1 @@
+# Examples

--- a/docs/reference/graph_rag_example_helpers/index.md
+++ b/docs/reference/graph_rag_example_helpers/index.md
@@ -3,4 +3,3 @@
 ::: graph_rag_example_helpers
     options:
         show_submodules: true
-        show_root_toc_entry: false

--- a/docs/reference/graph_retriever/adapters.md
+++ b/docs/reference/graph_retriever/adapters.md
@@ -1,5 +1,7 @@
+---
+title: adapters
+---
+
 # graph_retriever.adapters
 
 ::: graph_retriever.adapters
-    options:
-      show_root_toc_entry: false

--- a/docs/reference/graph_retriever/edges.md
+++ b/docs/reference/graph_retriever/edges.md
@@ -1,5 +1,7 @@
+---
+title: edges
+---
+
 # graph_retriever.edges
 
 ::: graph_retriever.edges
- options:
-   show_root_toc_entry: false

--- a/docs/reference/graph_retriever/index.md
+++ b/docs/reference/graph_retriever/index.md
@@ -2,7 +2,6 @@
 
 ::: graph_retriever
     options:
-      show_root_toc_entry: false
       members:
         - Content
         - Node

--- a/docs/reference/graph_retriever/strategies.md
+++ b/docs/reference/graph_retriever/strategies.md
@@ -1,5 +1,7 @@
+---
+title: strategies
+---
+
 # graph_retriever.strategies
 
 ::: graph_retriever.strategies
-    options:
-      show_root_toc_entry: false

--- a/docs/reference/graph_retriever/utils.md
+++ b/docs/reference/graph_retriever/utils.md
@@ -1,5 +1,7 @@
+---
+title: utils
+---
+
 # graph_retriever.utils
 
 ::: graph_retriever.utils
- options:
-   show_root_toc_entry: false

--- a/docs/reference/langchain_graph_retriever/adapters.md
+++ b/docs/reference/langchain_graph_retriever/adapters.md
@@ -1,6 +1,9 @@
+---
+title: adapters
+---
+
 # langchain_graph_retriever.adapters
 
 ::: langchain_graph_retriever.adapters
     options:
-      show_root_toc_entry: false
       show_submodules: true

--- a/docs/reference/langchain_graph_retriever/index.md
+++ b/docs/reference/langchain_graph_retriever/index.md
@@ -1,5 +1,3 @@
 # langchain_graph_retriever
 
 ::: langchain_graph_retriever
-    options:
-      show_root_toc_entry: false

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,7 @@ plugins:
           docstring_style: numpy
           merge_init_into_class: true
           show_symbol_type_toc: true
+          show_root_full_path: true
           separate_signature: true
           show_signature_annotations: true
           signature_crossrefs: true
@@ -59,7 +60,7 @@ markdown_extensions:
 theme:
   name: material
   features:
-    # - navigation.indexes
+    - navigation.indexes
     - navigation.instant
     - navigation.sections
     - navigation.tabs
@@ -67,7 +68,6 @@ theme:
     - navigation.tracking
     - navigation.path
     - toc.follow
-    - toc.integrate
     - search.suggest
     - search.highlight
 

--- a/packages/graph-retriever/pyproject.toml
+++ b/packages/graph-retriever/pyproject.toml
@@ -39,7 +39,6 @@ classifiers = [
 ]
 
 dependencies = [
-    "pydantic>=2.10.4",
     "numpy>=1.26.4",
     "typing-extensions>=4.12.2",
     "pytest[testing]>=8.3.4",
@@ -60,7 +59,6 @@ testing = [
 
 [tool.deptry.package_module_name_map]
 numpy = "numpy"
-pydantic = "pydantic"
 pytest = "pytest"
 simsimd = "simsimd"
 typing-extensions = "typing_extensions"

--- a/packages/graph-retriever/src/graph_retriever/content.py
+++ b/packages/graph-retriever/src/graph_retriever/content.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
+import dataclasses
 from collections.abc import Callable
 from typing import Any
 
-from pydantic import BaseModel
 
-
-class Content(BaseModel):
+@dataclasses.dataclass
+class Content:
     """
     Model representing retrieved content.
 
@@ -30,7 +30,7 @@ class Content(BaseModel):
     id: str
     content: str
     embedding: list[float]
-    metadata: dict[str, Any] = {}
+    metadata: dict[str, Any] = dataclasses.field(default_factory=dict)
 
     mime_type: str = "text/plain"
     score: float | None = None
@@ -41,7 +41,7 @@ class Content(BaseModel):
         content: str,
         embedding: list[float] | Callable[[str], list[float]],
         score: float | None = None,
-        metadata: dict[str, Any] = {},
+        metadata: dict[str, Any] | None = None,
         mime_type: str = "text/plain",
     ) -> Content:
         """
@@ -73,6 +73,6 @@ class Content(BaseModel):
             content=content,
             embedding=embedding(content) if callable(embedding) else embedding,
             score=score,
-            metadata=metadata,
+            metadata=metadata or {},
             mime_type=mime_type,
         )

--- a/packages/graph-retriever/src/graph_retriever/edges/metadata.py
+++ b/packages/graph-retriever/src/graph_retriever/edges/metadata.py
@@ -55,12 +55,6 @@ class MetadataEdgeFunction:
         Definitions of edges for traversal, represented as a pair of fields
         representing the source and target of the edges.
 
-    Attributes
-    ----------
-    edges : list[EdgeSpec]
-        Definitions of edges for traversal, represented as a pair of fields
-        representing the source and target of the edges.
-
     Raises
     ------
     ValueError

--- a/packages/graph-retriever/src/graph_retriever/strategies/base.py
+++ b/packages/graph-retriever/src/graph_retriever/strategies/base.py
@@ -30,18 +30,6 @@ class Strategy(abc.ABC):
         Number of documents to fetch for each outgoing edge.
     max_depth : int, optional
         Maximum traversal depth. If `None`, there is no limit.
-
-    Attributes
-    ----------
-    k : int
-        Maximum number of nodes to retrieve during traversal.
-    start_k : int
-        Number of documents to fetch via similarity for starting the traversal.
-        Added to any initial roots provided to the traversal.
-    adjacent_k : int
-        Number of documents to fetch for each outgoing edge.
-    max_depth : int
-        Maximum traversal depth. If `None`, there is no limit.
     """
 
     k: int = 5

--- a/packages/graph-retriever/src/graph_retriever/strategies/eager.py
+++ b/packages/graph-retriever/src/graph_retriever/strategies/eager.py
@@ -1,5 +1,6 @@
 """Provide eager (breadth-first) traversal strategy."""
 
+import dataclasses
 from collections.abc import Iterable
 
 from typing_extensions import override
@@ -8,6 +9,7 @@ from graph_retriever.strategies.base import Strategy
 from graph_retriever.types import Node
 
 
+@dataclasses.dataclass
 class Eager(Strategy):
     """
     Eager traversal strategy (breadth-first).
@@ -42,7 +44,7 @@ class Eager(Strategy):
         Maximum traversal depth. If `None`, there is no limit.
     """
 
-    _nodes: list[Node] = []
+    _nodes: list[Node] = dataclasses.field(default_factory=list)
 
     @override
     def discover_nodes(self, nodes: dict[str, Node]) -> None:

--- a/packages/graph-retriever/src/graph_retriever/strategies/eager.py
+++ b/packages/graph-retriever/src/graph_retriever/strategies/eager.py
@@ -30,18 +30,6 @@ class Eager(Strategy):
         Number of documents to fetch for each outgoing edge.
     max_depth : int, optional
         Maximum traversal depth. If `None`, there is no limit.
-
-    Attributes
-    ----------
-    k : int
-        Maximum number of nodes to retrieve during traversal.
-    start_k : int
-        Number of documents to fetch via similarity for starting the traversal.
-        Added to any initial roots provided to the traversal.
-    adjacent_k : int
-        Number of documents to fetch for each outgoing edge.
-    max_depth : int
-        Maximum traversal depth. If `None`, there is no limit.
     """
 
     _nodes: list[Node] = dataclasses.field(default_factory=list)

--- a/packages/graph-retriever/src/graph_retriever/strategies/mmr.py
+++ b/packages/graph-retriever/src/graph_retriever/strategies/mmr.py
@@ -6,7 +6,6 @@ from functools import cached_property
 
 import numpy as np
 from numpy.typing import NDArray
-from pydantic import Field
 from typing_extensions import override
 
 from graph_retriever.strategies.base import Strategy
@@ -40,6 +39,7 @@ class _MmrCandidate:
             self.score = self.weighted_similarity - self.weighted_redundancy
 
 
+@dataclasses.dataclass
 class Mmr(Strategy):
     """
     Maximal Marginal Relevance (MMR) traversal strategy.
@@ -88,16 +88,16 @@ class Mmr(Strategy):
         selected.
     """
 
-    lambda_mult: float = Field(default=0.5, ge=0.0, le=1.0)
+    lambda_mult: float = 0.5
     score_threshold: float = NEG_INF
 
-    _selected_ids: list[str] = []
+    _selected_ids: list[str] = dataclasses.field(default_factory=list)
     """List of selected IDs (in selection order)."""
 
-    _candidate_id_to_index: dict[str, int] = {}
+    _candidate_id_to_index: dict[str, int] = dataclasses.field(default_factory=dict)
     """Dictionary of candidate IDs to indices in candidates and candidate_embeddings."""
 
-    _candidates: list[_MmrCandidate] = []
+    _candidates: list[_MmrCandidate] = dataclasses.field(default_factory=list)
     """List containing information about candidates.
     Same order as rows in `candidate_embeddings`.
     """

--- a/packages/graph-retriever/src/graph_retriever/strategies/mmr.py
+++ b/packages/graph-retriever/src/graph_retriever/strategies/mmr.py
@@ -67,25 +67,6 @@ class Mmr(Strategy):
     score_threshold : float, default -infinity
         Only nodes with a score greater than or equal to this value will be
         selected.
-
-    Attributes
-    ----------
-    k : int
-        Maximum number of nodes to retrieve during traversal.
-    start_k : int
-        Number of documents to fetch via similarity for starting the traversal.
-        Added to any initial roots provided to the traversal.
-    adjacent_k : int
-        Number of documents to fetch for each outgoing edge.
-    max_depth : int
-        Maximum traversal depth. If `None`, there is no limit.
-    lambda_mult : float
-        Controls the trade-off between relevance and diversity. A value closer
-        to 1 prioritizes relevance, while a value closer to 0 prioritizes
-        diversity. Must be between 0 and 1 (inclusive).
-    score_threshold : float
-        Only nodes with a score greater than or equal to this value will be
-        selected.
     """
 
     lambda_mult: float = 0.5

--- a/packages/graph-retriever/src/graph_retriever/strategies/scored.py
+++ b/packages/graph-retriever/src/graph_retriever/strategies/scored.py
@@ -1,8 +1,7 @@
+import dataclasses
 import heapq
 from collections.abc import Callable, Iterable
-from typing import Annotated
 
-from pydantic import WithJsonSchema
 from typing_extensions import override
 
 from graph_retriever.strategies.base import Strategy
@@ -18,16 +17,14 @@ class _ScoredNode:
         return other.score < self.score
 
 
+@dataclasses.dataclass
 class Scored(Strategy):
     """Strategy selecing nodes using a scoring function."""
 
-    scorer: Annotated[
-        Callable[[Node], float],
-        WithJsonSchema({"type": "callable", "examples": [1, 0, -1]}),
-    ]
-    per_iteration_limit: int | None = None
+    scorer: Callable[[Node], float]
+    _nodes: list[_ScoredNode] = dataclasses.field(default_factory=list)
 
-    _nodes: list[_ScoredNode] = []
+    per_iteration_limit: int | None = None
 
     @override
     def discover_nodes(self, nodes: dict[str, Node]) -> None:

--- a/packages/graph-retriever/src/graph_retriever/traversal.py
+++ b/packages/graph-retriever/src/graph_retriever/traversal.py
@@ -1,5 +1,6 @@
 """Implements the traversal logic for graph-based document retrieval."""
 
+import copy
 from collections.abc import Iterable, Sequence
 from typing import Any
 
@@ -52,7 +53,7 @@ def traverse(
     traversal = _Traversal(
         query=query,
         edges=edges,
-        strategy=strategy.model_copy(deep=True),
+        strategy=copy.deepcopy(strategy),
         store=store,
         metadata_filter=metadata_filter,
         initial_root_ids=initial_root_ids,
@@ -103,7 +104,7 @@ async def atraverse(
     traversal = _Traversal(
         query=query,
         edges=edges,
-        strategy=strategy.model_copy(deep=True),
+        strategy=copy.deepcopy(strategy),
         store=store,
         metadata_filter=metadata_filter,
         initial_root_ids=initial_root_ids,

--- a/packages/graph-retriever/tests/strategies/test_base.py
+++ b/packages/graph-retriever/tests/strategies/test_base.py
@@ -1,3 +1,5 @@
+import dataclasses
+
 import pytest
 from graph_retriever.strategies import (
     Eager,
@@ -18,7 +20,9 @@ def test_build_strategy_base():
     assert strategy == Eager(k=7, start_k=5, adjacent_k=9, max_depth=2)
 
     # base strategy with invalid kwarg
-    with pytest.warns(UserWarning, match=r"Unsupported key\(s\) 'invalid_kwarg' set."):
+    with pytest.raises(
+        TypeError, match=r"got an unexpected keyword argument 'invalid_kwarg'"
+    ):
         strategy = Strategy.build(base_strategy=base_strategy, invalid_kwarg=4)
         assert strategy == base_strategy
 
@@ -31,7 +35,7 @@ def test_build_strategy_base_override():
     strategy = Strategy.build(
         base_strategy=base_strategy, strategy=override_strategy, k=4
     )
-    assert strategy == override_strategy.model_copy(update={"k": 4})
+    assert strategy == dataclasses.replace(override_strategy, k=4)
 
     # override base strategy and change params
     strategy = Strategy.build(
@@ -40,14 +44,15 @@ def test_build_strategy_base_override():
     assert strategy == Eager(k=3, start_k=4, adjacent_k=7, max_depth=3)
 
     # override base strategy and invalid kwarg
-    with pytest.warns(UserWarning, match=r"Unsupported key\(s\) 'invalid_kwarg' set."):
+    with pytest.raises(
+        TypeError, match=r"got an unexpected keyword argument 'invalid_kwarg'"
+    ):
         strategy = Strategy.build(
             base_strategy=base_strategy,
             strategy=override_strategy,
             k=4,
             invalid_kwarg=4,
         )
-        assert strategy == override_strategy.model_copy(update={"k": 4})
 
     # attempt override base strategy with dict
     with pytest.raises(ValueError, match="Unsupported 'strategy'"):
@@ -62,7 +67,9 @@ def test_build_strategy_base_override_mmr():
     override_strategy = Mmr(k=7, start_k=4, adjacent_k=8, max_depth=3, lambda_mult=0.3)
 
     # override base strategy with mmr kwarg
-    with pytest.warns(UserWarning, match=r"Unsupported key\(s\) 'lambda_mult' set."):
+    with pytest.raises(
+        TypeError, match="got an unexpected keyword argument 'lambda_mult'"
+    ):
         strategy = Strategy.build(base_strategy=base_strategy, lambda_mult=0.2)
         assert strategy == base_strategy
 
@@ -70,7 +77,7 @@ def test_build_strategy_base_override_mmr():
     strategy = Strategy.build(
         base_strategy=base_strategy, strategy=override_strategy, k=4
     )
-    assert strategy == override_strategy.model_copy(update={"k": 4})
+    assert strategy == dataclasses.replace(override_strategy, k=4)
 
     # override base strategy with mmr strategy and mmr arg
     strategy = Strategy.build(
@@ -79,7 +86,9 @@ def test_build_strategy_base_override_mmr():
     assert strategy == Mmr(k=4, start_k=4, adjacent_k=8, max_depth=3, lambda_mult=0.2)
 
     # start with override strategy, change to base, try to set mmr arg
-    with pytest.warns(UserWarning, match=r"Unsupported key\(s\) 'lambda_mult' set."):
+    with pytest.raises(
+        TypeError, match="got an unexpected keyword argument 'lambda_mult'"
+    ):
         Strategy.build(
             base_strategy=override_strategy, strategy=base_strategy, lambda_mult=0.2
         )

--- a/packages/graph-retriever/tests/testing/invoker.py
+++ b/packages/graph-retriever/tests/testing/invoker.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import abc
+import dataclasses
 from collections.abc import Callable, Sequence
 from typing import Any, Generic, TypeVar
 
@@ -79,7 +80,7 @@ class TraversalCall(Generic[T]):
         **kwargs: Any,
     ) -> T:
         strategy = _pick("strategy", strategy, self.strategy)
-        strategy = strategy.model_copy(update=kwargs)
+        strategy = dataclasses.replace(strategy, **kwargs)
 
         results = await self.sync_or_async._traverse(
             query=_pick("query", query, self.query),

--- a/packages/langchain-graph-retriever/src/langchain_graph_retriever/graph_retriever.py
+++ b/packages/langchain-graph-retriever/src/langchain_graph_retriever/graph_retriever.py
@@ -1,5 +1,6 @@
 """Provides a graph-based retriever combining vector search and graph traversal."""
 
+import dataclasses
 from collections.abc import Sequence
 from functools import cached_property
 from typing import (
@@ -31,19 +32,6 @@ class GraphRetriever(BaseRetriever):
     supports multiple traversal strategies and integrates seamlessly with
     LangChain's retriever framework.
 
-    Parameters
-    ----------
-    store : Adapter | VectorStore
-        The adapter or vector store used for document retrieval.
-    edges : list[EdgeSpec] | EdgeFunction, default []
-        A list of [EdgeSpec][graph_retriever.edges.EdgeSpec] for use in creating a
-        [MetadataEdgeFunction][graph_retriever.edges.MetadataEdgeFunction],
-        or an [EdgeFunction][graph_retriever.edges.EdgeFunction].
-    strategy : Strategy, default Eager
-        The traversal strategy to use.
-        Defaults to an [Eager][graph_retriever.strategies.Eager] (breadth-first)
-        strategy which explores the top `adjacent_k` for each edge.
-
     Attributes
     ----------
     store : Adapter | VectorStore
@@ -54,8 +42,6 @@ class GraphRetriever(BaseRetriever):
         or an [EdgeFunction][graph_retriever.edges.EdgeFunction].
     strategy : Strategy
         The traversal strategy to use.
-    adapter: Adapter
-        The adapter to use during traversals
     """
 
     store: Adapter | VectorStore
@@ -81,9 +67,7 @@ class GraphRetriever(BaseRetriever):
             The updated GraphRetriever instance.
         """
         if self.model_extra:
-            self.strategy = self.strategy.model_validate(
-                {**self.strategy.model_dump(), **self.model_extra}
-            )
+            self.strategy = dataclasses.replace(self.strategy, **self.model_extra)
             self.model_extra.clear()
         return self
 

--- a/packages/langchain-graph-retriever/tests/test_graph_retriever.py
+++ b/packages/langchain-graph-retriever/tests/test_graph_retriever.py
@@ -1,3 +1,4 @@
+import copy
 from collections.abc import Iterable
 
 from graph_retriever.edges.metadata import Id
@@ -15,7 +16,7 @@ def test_mmr_parameters() -> None:
     mmr1._query_embedding = [0.25, 0.5, 0.75]
     assert id(mmr1._nd_query_embedding) == id(mmr1._nd_query_embedding)
 
-    mmr2 = mmr1.model_copy(deep=True)
+    mmr2 = copy.deepcopy(mmr1)
     assert id(mmr1._nd_query_embedding) != id(mmr2._nd_query_embedding)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1295,7 +1295,6 @@ version = "0.1.0"
 source = { editable = "packages/graph-retriever" }
 dependencies = [
     { name = "numpy" },
-    { name = "pydantic" },
     { name = "pytest" },
     { name = "typing-extensions" },
 ]
@@ -1316,7 +1315,6 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "numpy", specifier = ">=1.26.4" },
-    { name = "pydantic", specifier = ">=2.10.4" },
     { name = "pytest", marker = "extra == 'testing'", specifier = ">=8.3.4" },
     { name = "pytest", extras = ["testing"], specifier = ">=8.3.4" },
     { name = "simsimd", marker = "extra == 'simsimd'", specifier = ">=6.2.1" },


### PR DESCRIPTION
Enable `--strict` in the build docs CI step.

Does *not* use `--strict` when deploying docs
(prefer publishing with warnings), but that
shouldn't come up unless the CI step is skipped.
Also doesn't use `--strict` in the Poe settings to allow local iteration with warnings.