### PR TITLE
fix: Track discovered nodes to avoid "rediscovery"

### DIFF
--- a/packages/graph-retriever/src/graph_retriever/strategies/base.py
+++ b/packages/graph-retriever/src/graph_retriever/strategies/base.py
@@ -7,7 +7,6 @@ import dataclasses
 from collections.abc import Iterable
 from typing import Any
 
-from graph_retriever.content import Content
 from graph_retriever.types import Node
 
 DEFAULT_SELECT_K = 5
@@ -63,7 +62,7 @@ class NodeTracker:
         new_nodes = {
             n.id: n
             for n in nodes
-            if self._not_visited(n)
+            if self._not_visited(n.id)
             if self._max_depth is None or n.depth < self._max_depth
         }
         self.to_traverse.update(new_nodes)
@@ -90,9 +89,9 @@ class NodeTracker:
         self.select(nodes)
         return self.traverse(nodes)
 
-    def _not_visited(self, item: Content | Node):
-        """Return true if the content or node has not been visited."""
-        return item.id not in self._visited_node_ids
+    def _not_visited(self, id: str):
+        """Return true if the node has not been visited."""
+        return id not in self._visited_node_ids
 
     def _should_stop_traversal(self):
         """Return true if traversal should be stopped."""

--- a/packages/graph-retriever/src/graph_retriever/strategies/mmr.py
+++ b/packages/graph-retriever/src/graph_retriever/strategies/mmr.py
@@ -257,7 +257,8 @@ class Mmr(Strategy):
     @override
     def iteration(self, nodes: Iterable[Node], tracker: NodeTracker) -> None:
         """Add candidates to the consideration set."""
-        node_count = len(list(nodes))
+        nodes = list(nodes)
+        node_count = len(nodes)
         if node_count > 0:
             # Build up a matrix of the remaining candidate embeddings.
             # And add them to the candidate set
@@ -306,6 +307,7 @@ class Mmr(Strategy):
 
         while tracker.num_remaining > 0:
             next = self._next()
+
             if next is None:
                 break
 

--- a/packages/graph-retriever/tests/strategies/test_mmr.py
+++ b/packages/graph-retriever/tests/strategies/test_mmr.py
@@ -35,6 +35,26 @@ async def test_animals_keywords(animals: Adapter, sync_or_async: SyncOrAsync):
     ]
 
 
+async def test_rediscovering(animals: Adapter, sync_or_async: SyncOrAsync):
+    """Test for https://github.com/datastax/graph-rag/issues/167.
+
+    The issue was nodes were being "rediscovered" and readded to the candidates
+    list in MMR. This violates the contract of the traversal. This test runs MMR
+    with a high number of iterations (select 97 nodes, 1 at a time) and a high
+    adjacent K (100) nodes at each iteration. This ensures that some nodes will
+    be rediscovered.
+    """
+    traversal = sync_or_async.traverse_sorted_ids(
+        store=animals,
+        edges=[("habitat", "habitat")],
+    )
+    result = await traversal(
+        query="cat",
+        strategy=Mmr(select_k=97, adjacent_k=100, start_k=100, lambda_mult=0.9),
+    )
+    assert len(result) == 97
+
+
 async def test_animals_habitat(animals: Adapter, sync_or_async: SyncOrAsync):
     """Test traversing a bi-directional field with singular values."""
     traversal = sync_or_async.traverse_sorted_ids(


### PR DESCRIPTION
This violated the contract of `iteration` which says that the `nodes` passed in are *new* (not already received). In turn, this was breaking some of the candidate tracking in MMR since duplicates were arising.

This closes #167.